### PR TITLE
chore(default): Use SonarTech as renovate author

### DIFF
--- a/default.json
+++ b/default.json
@@ -8,6 +8,7 @@
         ":disableDependencyDashboard",
         ":rebaseStalePrs"
     ],
+    "gitAuthor": "Renovate Bot <1842438+RenovateBot@users.noreply.github.com>",
     "packageRules": [
         {
             "matchDepTypes": [


### PR DESCRIPTION
To allow cirrus runs, an account with write access needs to be the author of commits.