### PR TITLE
fix(BUILD-1287): fix ownership to platform-devinfra-squad

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-.github/CODEOWNERS @sonarsource/platform-devinfra-squad
+* @sonarsource/platform-devinfra-squad
 
 # No review needed for documentation changes
 *.md

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-* @sonarsource/re-team
+.github/CODEOWNERS @sonarsource/platform-devinfra-squad
 
 # No review needed for documentation changes
 *.md


### PR DESCRIPTION
Set the team `platform-devinfra-squad` as code owner in `.github` file.

A clear unique ownership is required. See [BUILD-1271](https://jira.sonarsource.com/browse/BUILD-1271).
Contact Release Engineering Team for more information.


[BUILD-1271]: https://sonarsource.atlassian.net/browse/BUILD-1271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ