### PR TITLE
chore(BUILD-4956): improve regular expression matching AMIs in HCL sources

### DIFF
--- a/re-team.json
+++ b/re-team.json
@@ -39,7 +39,7 @@
                 ".*tfvars$"
             ],
             "matchStrings": [
-                ".*amiFilter=(?<packageName>.*?)\\n(.*currentImageName=(?<currentDigest>.*?)\\n)?(.*\\n)?.*?(?<depName>[a-zA-Z0-9-_:.\"]*)[ ]*?[:|=][ ]*?[\\\"|\"]?(?<currentValue>ami-[a-z0-9]{17})[\\\"|\"]?.*"
+                ".*amiFilter=(?<packageName>.*?)\\n(.*currentImageName=(?<currentDigest>.*?)\\n)?(.*\\n)?.*?(?<depName>[a-zA-Z0-9-_:.\"]*)[ ]*?=[ ]*?[\"](?<currentValue>ami-[a-z0-9]{17})[\"]"
             ],
             "datasourceTemplate": "aws-machine-image",
             "versioningTemplate": "aws-machine-image"


### PR DESCRIPTION
Based on the feedback from @Godin at https://github.com/SonarSource/renovate-config/pull/24

Tested in re-ci-images. There is no change in the outputs of renovate

```bash
$ GITHUB_COM_TOKEN=$(gh auth token) LOG_LEVEL=debug npx -- renovate --platform=local 
...
DEBUG: Repository config (repository=local)
       "fileName": ".github/renovate.json",
       "config": {
         "extends": [
           "github>SonarSource/renovate-config:re-team#chore/mm/fix-review-findings"
         ]
       }
...
 INFO: Dependency extraction complete (repository=local)
       "stats": {
         "managers": {
           "github-actions": {"fileCount": 3, "depCount": 17},
           "regex": {"fileCount": 2, "depCount": 8}
         },
         "total": {"fileCount": 5, "depCount": 25}
       }
..
DEBUG: 8 flattened updates found: windows_2022_ami_id, ubuntu_arm64_ami_id, "xenial-16.04", "bionic-18.04", "focal-20.04", "jammy-22.04", SonarSource/cirrus-modules, SonarSource/cirrus-modules (repository=local)
...
DEBUG: Lookup statistics (repository=local)
       "github-runners": {"count": 1, "avgMs": 15, "medianMs": 15, "maxMs": 15, "totalMs": 15},
       "github-tags": {"count": 13, "avgMs": 60, "medianMs": 63, "maxMs": 79, "totalMs": 786},
       "aws-machine-image": {"count": 6, "avgMs": 29, "medianMs": 33, "maxMs": 34, "totalMs": 176},
       "github-releases": {"count": 2, "avgMs": 433, "medianMs": 597, "maxMs": 597, "totalMs": 865}
...
```