### PR TITLE
feat(BUILD-4884): enable maven manager in re-team config

### DIFF
--- a/re-team.json
+++ b/re-team.json
@@ -9,7 +9,8 @@
     ],
     "enabledManagers": [
         "github-actions",
-        "custom.regex"
+        "custom.regex",
+        "maven"
     ],
     "configMigration": true,
     "addLabels": [


### PR DESCRIPTION
tested on parent-oss

```bash
$ GITHUB_COM_TOKEN=$(gh auth token) LOG_LEVEL=debug npx -- renovate --platform=local
...
DEBUG: Repository config (repository=local)
       "fileName": ".github/renovate.json",
       "config": {
         "$schema": "https://docs.renovatebot.com/renovate-schema.json",
         "extends": ["github>SonarSource/renovate-config:re-team#feat/mm/build-4884"]
       }
...
DEBUG: Lookup statistics (repository=local)
       "github-tags": {"count": 1, "avgMs": 32, "medianMs": 32, "maxMs": 32, "totalMs": 32},
       "maven": {"count": 29, "avgMs": 93, "medianMs": 68, "maxMs": 266, "totalMs": 2685}
```