### PR TITLE
fix(BUILD-4946): remove quotes from dependency names

### DIFF
--- a/re-team.json
+++ b/re-team.json
@@ -42,7 +42,8 @@
                 ".*amiFilter=(?<packageName>.*?)\\n(.*currentImageName=(?<currentDigest>.*?)\\n)?(.*\\n)?.*?(?<depName>[a-zA-Z0-9-_:.\"]*)[ ]*?[:|=][ ]*?[\\\"|\"]?(?<currentValue>ami-[a-z0-9]{17})[\\\"|\"]?.*"
             ],
             "datasourceTemplate": "aws-machine-image",
-            "versioningTemplate": "aws-machine-image"
+            "versioningTemplate": "aws-machine-image",
+            "depNameTemplate": "{{{replace '\"' '' depName}}}"
         },
         {
             "customType": "regex",


### PR DESCRIPTION
## Tested in re-ci-images

### Before
```
$ GITHUB_COM_TOKEN=$(gh auth token) LOG_LEVEL=debug npx -- renovate --platform=local
...
DEBUG: Repository config (repository=local)
       "fileName": ".github/renovate.json",
       "config": {"extends": ["github>SonarSource/renovate-config:re-team"]}
...
DEBUG: 9 flattened updates found: hashicorp/setup-packer, windows_2022_ami_id, ubuntu_arm64_ami_id, "xenial-16.04", "bionic-18.04", "focal-20.04", "jammy-22.04", SonarSource/cirrus-modules, SonarSource/cirrus-modules (repository=local)
...
               {
                 "depName": "\"xenial-16.04\"",
                 "packageName": "[{\"Name\":\"owner-id\",\"Values\":[\"850264050567\"]},{\"Name\":\"name\",\"Values\":[\"sonar-ubuntu-1604-x86-64*\"]}]",
                 "currentValue": "ami-01c3d3d797079b38b",
                 "currentDigest": "sonar-ubuntu-1604-x86-64 2024-02-19T07-00-50.633009Z",
                 "datasource": "aws-machine-image",
                 "versioning": "aws-machine-image",
                 "replaceString": "  # renovate: amiFilter=[{\"Name\":\"owner-id\",\"Values\":[\"850264050567\"]},{\"Name\":\"name\",\"Values\":[\"sonar-ubuntu-1604-x86-64*\"]}]\n  # currentImageName=sonar-ubuntu-1604-x86-64 2024-02-19T07-00-50.633009Z\n  \"xenial-16.04\" = \"ami-01c3d3d797079b38b\"",
                 "updates": [
                   {
                     "bucket": "non-major",
                     "newVersion": "ami-08eadcd44cb043d2b",
                     "newValue": "ami-08eadcd44cb043d2b",
                     "newDigest": "sonar-ubuntu-1604-x86-64 2024-05-06T07-00-50.995914Z",
                     "releaseTimestamp": "2024-05-06T07:08:44.000Z",
                     "newMajor": 1,
                     "newMinor": 0,
                     "updateType": "patch",
                     "branchName": "renovate/\"xenial-16.04\"-1.x"
                   }
                 ],
                 "warnings": [],
                 "currentVersion": "ami-01c3d3d797079b38b",
                 "isSingleVersion": true,
                 "fixedVersion": "ami-01c3d3d797079b38b"
               },
...
```

### After
```
$ GITHUB_COM_TOKEN=$(gh auth token) LOG_LEVEL=debug npx -- renovate --platform=local
...
DEBUG: Repository config (repository=local)
       "fileName": ".github/renovate.json",
       "config": {"extends": ["github>SonarSource/renovate-config:re-team#fix/mm/BUILD-4946"]}
...
DEBUG: 9 flattened updates found: hashicorp/setup-packer, windows_2022_ami_id, ubuntu_arm64_ami_id, xenial-16.04, bionic-18.04, focal-20.04, jammy-22.04, SonarSource/cirrus-modules, SonarSource/cirrus-modules (repository=local)
...
               {
                 "depName": "xenial-16.04",
                 "packageName": "[{\"Name\":\"owner-id\",\"Values\":[\"850264050567\"]},{\"Name\":\"name\",\"Values\":[\"sonar-ubuntu-1604-x86-64*\"]}]",
                 "currentValue": "ami-01c3d3d797079b38b",
                 "currentDigest": "sonar-ubuntu-1604-x86-64 2024-02-19T07-00-50.633009Z",
                 "datasource": "aws-machine-image",
                 "versioning": "aws-machine-image",
                 "replaceString": "  # renovate: amiFilter=[{\"Name\":\"owner-id\",\"Values\":[\"850264050567\"]},{\"Name\":\"name\",\"Values\":[\"sonar-ubuntu-1604-x86-64*\"]}]\n  # currentImageName=sonar-ubuntu-1604-x86-64 2024-02-19T07-00-50.633009Z\n  \"xenial-16.04\" = \"ami-01c3d3d797079b38b\"",
                 "updates": [
                   {
                     "bucket": "non-major",
                     "newVersion": "ami-08eadcd44cb043d2b",
                     "newValue": "ami-08eadcd44cb043d2b",
                     "newDigest": "sonar-ubuntu-1604-x86-64 2024-05-06T07-00-50.995914Z",
                     "releaseTimestamp": "2024-05-06T07:08:44.000Z",
                     "newMajor": 1,
                     "newMinor": 0,
                     "updateType": "patch",
                     "branchName": "renovate/xenial-16.04-1.x"
                   }
                 ],
                 "warnings": [],
                 "currentVersion": "ami-01c3d3d797079b38b",
                 "isSingleVersion": true,
                 "fixedVersion": "ami-01c3d3d797079b38b"
               },
...
```