### PR TITLE
BUILD-5480 Enable auto rebase of Renovate PR after some changes occurs on master branch (test on dev-infra-squad)

### DIFF
--- a/dev-infra-squad.json
+++ b/dev-infra-squad.json
@@ -2,6 +2,7 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
         "github>SonarSource/renovate-config",
+        ":rebaseStalePrs",
         ":maintainLockFilesWeekly",
         ":enablePreCommit",
         "docker:enableMajor",


### PR DESCRIPTION
The idea is to enable this option https://docs.renovatebot.com/presets-default/#rebasestaleprs that mimic more what Dependabot is doing (after a merge into master, then all PRs opened by Renovate get rebased automatically)


That way we can test on dev-infra-squad repositories this feature and see if it resolve the current issue: It needs days to be able to merge 2 PRs opened by Renovate if they impact any pylock files (need to be rebased by Renovate and this is very slow (takes one night)