### PR TITLE
BUILD-5601: Fix wrong regex for cirrus.star

### DIFF
--- a/dev-infra-squad.json
+++ b/dev-infra-squad.json
@@ -77,7 +77,6 @@
                 "^\\.cirrus\\.star$"
             ],
             "matchStrings": [
-                "datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n.*load.*\"github.com\\/.*@(?<currentValue>[a-f0-9.]+)\",.*",
                 "datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n.*load.*\"github.com\\/.*@(?<currentDigest>[a-f0-9]+)\",.* # (?<currentValue>.*)"
             ]
         },


### PR DESCRIPTION
BUILD-5601: Fix wrong regex for cirrus.star

Invalid PRs: 

https://github.com/SonarSource/ci-docker-images/pull/11
https://github.com/SonarSource/ci-docker-images/pull/13