### PR TITLE
BUILD-5601: Add regex for bash and Dockerfile

### DIFF
--- a/dev-infra-squad.json
+++ b/dev-infra-squad.json
@@ -83,6 +83,16 @@
         {
             "customType": "regex",
             "fileMatch": [
+                ".*\\.sh$",
+                ".*\\.?Dockerfile"
+            ],
+            "matchStrings": [
+                "datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n[ A-Z_]*=(?<currentValue>.*)"
+            ]
+        },
+        {
+            "customType": "regex",
+            "fileMatch": [
                 "^\\.cirrus\\.ya?ml$"
             ],
             "matchStrings": [


### PR DESCRIPTION
BUILD-5601: Add regex for bash and Dockerfile

Add regex to match the following examples

```
# renovate: datasource=github-releases depName=SonarSource/ci-common-scripts
CI_COMMON_SCRIPTS_VERSION=2.0.1
```

and 

```
# renovate: datasource=github-releases depName=shellspec/shellspec
ENV SHELL_SPEC_VERSION=0.28.1
```