### PR TITLE
BUILD-5671 Enable Renovate PR creation between 8h-17h between Monday-Friday

### DIFF
--- a/dev-infra-squad.json
+++ b/dev-infra-squad.json
@@ -7,6 +7,11 @@
         "docker:enableMajor",
         "docker:pinDigests"
     ],
+    "timezone": "Europe/Paris",
+    "schedule": [
+        "after 8pm every weekday",
+        "before 5am every weekday"
+    ],
     "enabledManagers": [
         "github-actions",
         "custom.regex",


### PR DESCRIPTION
That way we get notifications only during Office hours

> This only applies to the dev-infra-squad template (will not impact anyone else)