### PR TITLE
fix(BUILD-5838): add explicit auth config for poetry

### DIFF
--- a/default.json
+++ b/default.json
@@ -34,6 +34,12 @@
         {
             "matchHost": "repox.jfrog.io",
             "token": "{{ secrets.REPOX_TOKEN }}"
+        },
+        {
+            "hostType": "pypi",
+            "matchHost": "repox.jfrog.io",
+            "username": "renovate-read",
+            "password": "{{ secrets.REPOX_TOKEN }}"
         }
     ]
 }


### PR DESCRIPTION
It's necessary to set `username` and `password` properties for the Poetry artifact update to work. See: https://docs.renovatebot.com/getting-started/private-packages/#poetry