### PR TITLE
fix(BUILD-5671): allow Renovate at any time

### DIFF
--- a/dev-infra-squad.json
+++ b/dev-infra-squad.json
@@ -9,8 +9,8 @@
     ],
     "timezone": "Europe/Paris",
     "schedule": [
-        "after 8am every weekday",
-        "before 5pm every weekday"
+        "after 7am every weekday",
+        "before 8pm every weekday"
     ],
     "enabledManagers": [
         "github-actions",


### PR DESCRIPTION
The implemented timebox is too small. While it’s handy to be able to run it during office hours, it is also an issue that it collides with human work occurring during office hours.

-> Increasing the timebox from 8h-17h to 7h-20h.