### PR TITLE
BUILD-5671 renovate config enable renovate pr creation within office hours instead of out of office hours dev infra squad

### DIFF
--- a/dev-infra-squad.json
+++ b/dev-infra-squad.json
@@ -7,6 +7,11 @@
         "docker:enableMajor",
         "docker:pinDigests"
     ],
+    "timezone": "Europe/Paris",
+    "schedule": [
+        "after 8pm every weekday",
+        "before 5am every weekday"
+    ],
     "enabledManagers": [
         "github-actions",
         "custom.regex",

--- a/dev-infra-squad.json
+++ b/dev-infra-squad.json
@@ -38,6 +38,15 @@
             "addLabels": [
                 "golden-ami"
             ]
+        },
+        {
+            "groupName": "GitHub actions updates",
+            "matchManagers": [
+                "github-actions"
+            ],
+            "groupSlug": "github-actions",
+            "separateMinorPatch": false,
+            "automerge": true
         }
     ],
     "customManagers": [


### PR DESCRIPTION
## Changes

- [x] Regroup github actions updates into a single PR (Applies only to DevInfra Squad)
- [x] Enable `automerge: true` - Note: It doesn't mean the PR will be merged without review, it will click the button "automatically merge after checks pass" when the PR has been reviewed and approved (1 click less for the reviewer)