### PR TITLE
BUILD-6956 Update dev-infra-squad.json

### DIFF
--- a/dev-infra-squad.json
+++ b/dev-infra-squad.json
@@ -38,6 +38,15 @@
             "addLabels": [
                 "golden-ami"
             ]
+        },
+        {
+            "groupName": "GitHub actions updates",
+            "matchManagers": [
+                "github-actions"
+            ],
+            "groupSlug": "github-actions",
+            "separateMinorPatch": false,
+            "automerge": true
         }
     ],
     "customDatasources": {


### PR DESCRIPTION
## Changes

- [x] Group gh-actions updates in a same PR for DevInfra repositories
- [x] Enable `automerge: true` : Note: This will not merge PR without review, instead: when reviewed, it will "click" the "Enable auto-merge" button. That way the reviewer just have to review + approve the PR, renovate do the rest (1 click less) 