### PR TITLE
BUILD-7224 Regroup python minor and patch deps renovate PRs into one PR

### DIFF
--- a/dev-infra-squad.json
+++ b/dev-infra-squad.json
@@ -47,6 +47,16 @@
             "groupSlug": "github-actions",
             "separateMinorPatch": false,
             "automerge": true
+        },
+        {
+            "groupName": "Python dependencies updates",
+            "matchManagers": [
+                "poetry",
+                "pipenv"
+            ],
+            "groupSlug": "python-deps",
+            "separateMinorPatch": false,
+            "automerge": true
         }
     ],
     "customDatasources": {


### PR DESCRIPTION
Following what was done with github actions PR, python dependencies minor and patch could also benefit from a groupped approach. It would ease maintenance effort as these upgrade should also not contain breaking changes according to semver principles.

Additionally it will reduce financial costs of AWS resources as each Renovate PR in infra projects is expensive.