### PR TITLE
BUILD-7804: Disable automerge in renovate config

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,7 +6,7 @@ jobs:
     name: "pre-commit"
     runs-on: ubuntu-latest
     steps:
-      - uses: SonarSource/gh-action_pre-commit@a82df1c1afb2b6460c141f4fbec7add081f97a9f # 1.0.2
+      - uses: SonarSource/gh-action_pre-commit@fc9d73025994fd1c2b96d568c8c8a4af82a3ae21 # 1.0.6
         with:
           extra-args: >
             --from-ref=origin/${{ github.event.pull_request.base.ref }}

--- a/cloud-platform-squad.json
+++ b/cloud-platform-squad.json
@@ -5,7 +5,7 @@
     "schedule": [
         "* 9-11 * * 4"
     ],
-    "automerge": true,
+    "automerge": false,
     "packageRules": [
         {
             "groupName": "all non-major dependencies",

--- a/dev-infra-squad.json
+++ b/dev-infra-squad.json
@@ -46,7 +46,7 @@
             ],
             "groupSlug": "github-actions",
             "separateMinorPatch": false,
-            "automerge": true
+            "automerge": false
         },
         {
             "groupName": "Python dependencies updates",
@@ -56,7 +56,7 @@
             ],
             "groupSlug": "python-deps",
             "separateMinorPatch": false,
-            "automerge": true
+            "automerge": false
         }
     ],
     "vulnerabilityAlerts": {


### PR DESCRIPTION
BUILD-7804: Disable automerge in renovate config

these configs are not used anywhere since renovate don't have the permission to automerge in any repos at the moment