### PR TITLE
Fix cronjob syntax for integration squad

### DIFF
--- a/orchestration-integration-squad.json
+++ b/orchestration-integration-squad.json
@@ -15,7 +15,7 @@
         "poetry"
     ],
     "schedule": [
-        "0 9 * * 1"
+        "* 9 * * 1"
     ],
     "automerge": false,
     "packageRules": [


### PR DESCRIPTION
Follow-up of:
https://github.com/SonarSource/renovate-config/pull/70/files

---

Fixing issue:
![image](https://github.com/user-attachments/assets/3467a27c-5fa4-42dc-a79e-f6c34ed0b03f)

---

[crontab.guru](https://crontab.guru/#*_9_*_*_1) visualization:
![image](https://github.com/user-attachments/assets/74c9d852-b97b-4d4f-9248-1d742c8ac49b)
