### PR TITLE
BUILD-8092 allow use of packageName instead of depName

### DIFF
--- a/dev-infra-squad.json
+++ b/dev-infra-squad.json
@@ -125,12 +125,13 @@
         },
         {
             "customType": "regex",
+            "comment": "Match legacy depName and new packageName parameters",
             "fileMatch": [
                 ".*\\.sh$",
                 ".*\\.?Dockerfile"
             ],
             "matchStrings": [
-                "datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n[ A-Z_]*=(?<currentValue>.*)"
+                "datasource=(?<datasource>\\S+) *(?:depName=(?<depName>\\S+)|packageName=(?<packageName>\\S+))?.*?\\n[ A-Z_]*=(?<currentValue>.*)"
             ]
         },
         {
@@ -139,7 +140,7 @@
                 ".*\\.?Dockerfile"
             ],
             "matchStrings": [
-                "datasource=(?<datasource>mend-.*?) depName=(?<depName>.*?)\\n[ A-Z_]*=(?<currentValue>.*)"
+                "datasource=(?<datasource>mend-\\S+) depName=(?<depName>\\S+).*?\\n[ A-Z_]*=(?<currentValue>.*)"
             ],
             "extractVersionTemplate": "^[a-zA-Z-]*_(?<version>.+)"
         },


### PR DESCRIPTION
~Allow for instance to pass allowedVersions parameter to the github-releases datasource~ this didn't work, however the change allows to ignore additional values in the Renovate comment.

Also, improve the parsing to capture datasource and packageName or depName names without spaces
Allow use of packageName instead of depName

Tested with https://github.com/SonarSource/docker-images/pull/55 to restrict the version to 3.x in `base-cirrusci/Dockerfile`:
```
       "fileName": ".github/renovate.json",
       "config": {
         "extends": [
           "github>SonarSource/renovate-config:dev-infra-squad#feat/jcarsique/BUILD-8092-flexibleParsing"
         ],
         "packageRules": [
           {
             "description": "Restrict ci-common-scripts to v3 for the legacy base-cirrusci Dockerfile",
             "matchPackageNames": ["SonarSource/ci-common-scripts"],
             "matchFileNames": ["base-cirrusci/Dockerfile"],
             "allowedVersions": "^3.0.0"
           }
         ]
       }
```
results in
```
               {
                 "packageName": "SonarSource/ci-common-scripts",
                 "currentValue": "3.7.0",
                 "datasource": "github-releases",
                 "replaceString": "datasource=github-releases packageName=SonarSource/ci-common-scripts\nARG CI_COMMON_SCRIPTS_VERSION=3.7.0",
                 "depName": "SonarSource/ci-common-scripts",
                 "updates": [],
                 "sourceUrl": "https://github.com/SonarSource/ci-common-scripts",
                 "currentVersion": "3.7.0",
                 "fixedVersion": "3.7.0"
               }
             ],
             "matchStrings": [
               "datasource=(?<datasource>\\S+) *(?:depName=(?<depName>\\S+)|packageName=(?<packageName>\\S+))?.*?\\n[ A-Z_]*=(?<currentValue>.*)"
             ],
             "packageFile": "base-cirrusci/Dockerfile"


               {
                 "packageName": "SonarSource/ci-common-scripts",
                 "currentValue": "3.7.0",
                 "datasource": "github-releases",
                 "replaceString": "datasource=github-releases packageName=SonarSource/ci-common-scripts\nARG CI_COMMON_SCRIPTS_VERSION=3.7.0",
                 "depName": "SonarSource/ci-common-scripts",
                 "updates": [
                   {
                     "newVersion": "4.0.0",
                     "newValue": "4.0.0",
                     "newMajor": 4,
                     "newMinor": 0,
                     "newPatch": 0,
                     "updateType": "major",
                     "branchName": "renovate/sonarsource-ci-common-scripts-4.x"
                   }
                 ],
                 "sourceUrl": "https://github.com/SonarSource/ci-common-scripts",
                 "currentVersion": "3.7.0",
                 "isSingleVersion": true,
                 "fixedVersion": "3.7.0"
               }
             ],
             "matchStrings": [
               "datasource=(?<datasource>\\S+) *(?:depName=(?<depName>\\S+)|packageName=(?<packageName>\\S+))?.*?\\n[ A-Z_]*=(?<currentValue>.*)"
             ],
             "packageFile": "base/Dockerfile"
```