### PR TITLE
BUILD-8504 Rename groups

### DIFF
--- a/dev-infra-squad.json
+++ b/dev-infra-squad.json
@@ -42,7 +42,7 @@
             ]
         },
         {
-            "groupName": "GitHub actions updates",
+            "groupName": "GitHub actions",
             "matchManagers": [
                 "github-actions"
             ],
@@ -51,7 +51,7 @@
             "automerge": false
         },
         {
-            "groupName": "Python dependencies updates",
+            "groupName": "Python dependencies",
             "matchManagers": [
                 "poetry",
                 "pipenv"


### PR DESCRIPTION
Update the group names, so PR titles are `Update GitHub actions` instead of `Update GitHub actions updates`