### PR TITLE
BUILD-10003 Add support for mise version updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,8 +13,8 @@ repos:
       - id: pretty-format-json
         args: [--autofix, --indent, "4", --no-sort-keys]
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.13.0
+    rev: 0.36.0
     hooks:
       - id: check-renovate
         name: Check renovate presets
-        files: ^renovate
+        files: \.json$

--- a/default.json
+++ b/default.json
@@ -27,6 +27,16 @@
             "registryUrls": [
                 "https://repox.jfrog.io/artifactory/sonarsource-releases"
             ]
+        },
+        {
+            "description": "Group all mise updates together (CalVer, not SemVer)",
+            "matchDepNames": [
+                "mise"
+            ],
+            "separateMajorMinor": false,
+            "separateMinorPatch": false,
+            "branchName": "renovate/mise",
+            "commitMessageExtra": "to {{newVersion}}"
         }
     ],
     "hostRules": [
@@ -39,6 +49,26 @@
             "matchHost": "repox.jfrog.io",
             "username": "renovate-read",
             "password": "{{ secrets.REPOX_TOKEN }}"
+        }
+    ],
+    "customManagers": [
+        {
+            "customType": "regex",
+            "description": "Update Mise version in jdx/mise-action. Matches: 'jdx/mise-action@...' followed by 'with:' block containing 'version: <currentValue>'",
+            "managerFilePatterns": [
+                "/(^|/)workflow-templates/.+\\.ya?ml$/",
+                "/(^|/)\\.github/workflows/.+\\.ya?ml$/",
+                "/(^|/)\\.github/actions/.+\\.ya?ml$/",
+                "/(^|/)action\\.ya?ml$/"
+            ],
+            "datasourceTemplate": "github-releases",
+            "packageNameTemplate": "jdx/mise",
+            "depNameTemplate": "mise",
+            "matchStrings": [
+                "jdx/mise-action[^\\n]*\\n\\s*with:\\s*\\n(?:\\s+(?!-\\s)\\S+:[^\\n]*\\n)*?\\s*version:\\s*(?<currentValue>[\\d.]+)"
+            ],
+            "extractVersionTemplate": "^v(?<version>.*)$",
+            "versioningTemplate": "regex:^(?<minor>\\d{4})\\.(?<patch>\\d+)\\.(?<build>\\d+)$"
         }
     ]
 }


### PR DESCRIPTION
### Summary

Adds a custom Renovate manager to track and update mise tool versions in GitHub Actions workflows.

### Details

[mise](https://github.com/jdx/mise) uses **Calendar Versioning (CalVer)** with format `YYYY.MM.BUILD` (e.g., `2025.12.12`). Since this isn't semantic versioning, a custom regex versioning template is used to prevent year changes from being treated as breaking changes.

**Versioning mapping:**

| CalVer Component | Renovate Mapping | Example |
|-----------------|------------------|---------|
| `YYYY` (Year) | `minor` | 2025 |
| `MM` (Month) | `patch` | 12 |
| `BUILD` | `build` | 12 |

This ensures:
- Year changes (e.g., 2024 → 2025) are classified as **minor** updates, not major/breaking
- All mise updates are grouped into a single PR on branch `renovate/mise`
- Updates are never marked as `isBreaking: true`

### Tested locally

- ✅ `2025.7.12` → `2025.12.12` detected as **patch** update (`isBreaking: false`)
- ✅ `2024.11.1` → `2025.12.12` detected as **minor** update (`isBreaking: false`)

### Files matched
- `workflow-templates/*.ya?ml` (organization workflow templates)
- `.github/workflows/*.ya?ml`
- `.github/actions/*.ya?ml`
- `**/action.ya?ml`
