### PR TITLE
BUILD-10003 Fix regex parsing issue

### DIFF
--- a/default.json
+++ b/default.json
@@ -65,7 +65,7 @@
             "packageNameTemplate": "jdx/mise",
             "depNameTemplate": "mise",
             "matchStrings": [
-                "jdx/mise-action[^\\n]*\\n\\s*with:\\s*\\n(?:\\s+(?!-\\s)\\S+:[^\\n]*\\n)*?\\s*version:\\s*(?<currentValue>[\\d.]+)"
+                "jdx/mise-action[^\\n]*\\n\\s*with:\\s*\\n(?:\\s+[a-zA-Z_][^:\\s]*:[^\\n]*\\n)*?\\s*version:\\s*(?<currentValue>[\\d.]+)"
             ],
             "extractVersionTemplate": "^v(?<version>.*)$",
             "versioningTemplate": "regex:^(?<minor>\\d{4})\\.(?<patch>\\d+)\\.(?<build>\\d+)$"


### PR DESCRIPTION
Use `[a-zA-Z_]` instead of `(?!-\s)\S+` which is RE2-compatible (no negative lookahead needed since `[a-zA-Z_]` naturally excludes `-`).

Tested with
```yaml
- uses: jdx/mise-action@146a28175021df8ca24f8ee1828cc2a60f980bd5 # v3.5.1
  with:
    install: true
    version: 2025.7.12
```