### PR TITLE
Add NuGet hostRule for JFrog Artifactory authentication

### DIFF
--- a/default.json
+++ b/default.json
@@ -49,6 +49,12 @@
             "matchHost": "repox.jfrog.io",
             "username": "renovate-read",
             "password": "{{ secrets.REPOX_TOKEN }}"
+        },
+        {
+            "hostType": "nuget",
+            "matchHost": "repox.jfrog.io",
+            "username": "renovate-read",
+            "password": "{{ secrets.REPOX_TOKEN }}"
         }
     ],
     "customManagers": [


### PR DESCRIPTION
## Summary
- Add `hostType: "nuget"` hostRule for `repox.jfrog.io`

## Problem
The README states that NuGet is supported, but the `hostRules` only include entries for:
- Generic HTTP (no `hostType`) - works for Renovate's internal HTTP lookups
- `hostType: "pypi"` - works for Python packages (added in #48 for the same reason)

When Renovate runs `dotnet restore` to update `packages.lock.json` files, it spawns a separate process that requires credentials via `nuget.config`. Without a `hostType: "nuget"` rule, Renovate doesn't pass credentials to the dotnet CLI.

This causes lock file updates to fail with 401 Unauthorized:
```
error NU1301: Unable to load the service index for source
https://repox.jfrog.io/artifactory/api/nuget/v3/nuget/index.json
Response status code does not indicate success: 401
```

Renovate then creates PRs with the message "Forcing PR because of artifact errors", resulting in PRs that only contain `.csproj`/`.targets` changes but no lock file updates.

## Solution
Add a NuGet-specific hostRule so Renovate generates proper credentials for the dotnet CLI:
```json
{
    "hostType": "nuget",
    "matchHost": "repox.jfrog.io",
    "username": "renovate-read",
    "password": "{{ secrets.REPOX_TOKEN }}"
}
```

## References
- Similar fix for Python/Poetry: #48
- Jira: https://sonarsource.atlassian.net/browse/NET-2770
- Renovate docs: https://docs.renovatebot.com/getting-started/private-packages/#nuget

## Affected Repositories
Any repository using `github>SonarSource/renovate-config` with NuGet packages and lock files, including:
- sonar-dotnet-enterprise
- sonar-dotnet-autoscan
- sonar-scanner-msbuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)