### PR TITLE
BUILD-10403 Add Renovate support for AMI updates in .gotmpl files

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,22 @@ amis = {
 - currentImageName: The name of the current image. Managed by renovate.
 - image_id: The ID of the current image. Managed by renovate.
 
+#### AWS Machine Images in Helm gotmpl files
+
+Replaces AMI IDs in Helm `*.gotmpl` files (e.g. Karpenter EC2NodeClass values). Uses the same `aws-machine-image` datasource.
+
+##### Example
+
+```yaml
+# renovate: amiFilter=[{"Name":"image-type","Values":["machine"]},{"Name":"name","Values":["sonar-amazon-eks-node-1-32 *"]},{"Name":"state","Values":["available"]},{"Name":"is-public","Values":["false"]}]
+# currentImageName=sonar-amazon-eks-node-1-32 2026-02-09T14-00-00.000000Z
+{{- $karpenter_ami_id := "ami-0b900a757ae0f2a4c" }}
+```
+
+- Supports both `# amiFilter=` and `# renovate: amiFilter=` prefixes
+- `currentImageName`: Image name and timestamp. Managed by Renovate
+- The Go template variable (`$var := "ami-xxx"`) is automatically updated
+
 #### AWS Machine Images in CDK projects
 
 Replaces version strings in `cdk.context.json` files. Works

--- a/dev-infra-squad.json
+++ b/dev-infra-squad.json
@@ -166,6 +166,18 @@
             ],
             "datasourceTemplate": "docker",
             "versioningTemplate": "docker"
+        },
+        {
+            "customType": "regex",
+            "description": "Update AMI IDs in Helm gotmpl files",
+            "fileMatch": [
+                "\\.gotmpl$"
+            ],
+            "matchStrings": [
+                "#\\s*(?:renovate:\\s*)?amiFilter=(?<packageName>\\[.*?\\])\\n#\\s*currentImageName=(?<depName>[^\\s]+) [\\d\\-T:.]+Z\\n\\{\\{-\\s*\\$?\\w+\\s*:=\\s*\\\"(?<currentValue>ami-[a-f0-9]+)\\\"\\s*\\}\\}"
+            ],
+            "datasourceTemplate": "aws-machine-image",
+            "versioningTemplate": "aws-machine-image"
         }
     ]
 }


### PR DESCRIPTION
Add custom regex manager to dev-infra-squad.json for Helm gotmpl files. Uses aws-machine-image datasource - matches format:
  # amiFilter=[...]
  # currentImageName=name timestamp
  {{- $var := "ami-xxx" }}

Supports both # amiFilter= and # renovate: amiFilter= prefixes. Enables github-runners-infra and other repos to receive AMI updates for Karpenter node classes without repo-specific config. Resolves BUILD-10373 security alerts on outdated node AMIs.