### PR TITLE
PREQ-4082 Add pinDigests false for SonarSource/* actions in default.json

### DIFF
--- a/default.json
+++ b/default.json
@@ -17,6 +17,17 @@
             "rollbackPrs": true
         },
         {
+            "description": "Internal SonarSource actions: use tags instead of digest pinning",
+            "matchDepTypes": [
+                "action"
+            ],
+            "matchPackagePatterns": [
+                "^SonarSource/"
+            ],
+            "pinDigests": false,
+            "rollbackPrs": true
+        },
+        {
             "matchDatasources": [
                 "maven"
             ],


### PR DESCRIPTION
## Summary
Adds a second package rule in `default.json` so internal GitHub Actions (`SonarSource/*`) use tags instead of digest pinning, while external actions stay pinned for security.

## Solution
New rule (first in `packageRules`, more specific):
- **matchDepTypes**: `action`
- **matchPackagePatterns**: `^SonarSource/`
- **pinDigests**: `false`
- **rangeStrategy**: `replace`

The existing generic action rule still applies to all other actions (pinDigests: true).

Relates to [PREQ-4082](https://sonarsource.atlassian.net/browse/PREQ-4082)

[PREQ-4082]: https://sonarsource.atlassian.net/browse/PREQ-4082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ