### PR TITLE
SC-42414 Fine-tune cloud platform renovate config

### DIFF
--- a/cloud-platform-squad.json
+++ b/cloud-platform-squad.json
@@ -3,7 +3,7 @@
         "github>SonarSource/renovate-config"
     ],
     "schedule": [
-        "* 9-11 * * 4"
+        "* 9-11 * * 0"
     ],
     "automerge": false,
     "labels": [
@@ -20,21 +20,59 @@
             "minimumReleaseAge": "5 days"
         },
         {
+            "description": "Group all patch updates in a single PR",
+            "matchUpdateTypes": [
+                "patch"
+            ],
+            "groupName": "all patch updates",
+            "groupSlug": "all-patch-updates"
+        },
+        {
+            "description": "Group all minor updates in a single PR",
+            "matchUpdateTypes": [
+                "minor"
+            ],
+            "groupName": "all minor updates",
+            "groupSlug": "all-minor-updates"
+        },
+        {
+            "description": "Group Gradle updates in a separate PR",
             "matchFileNames": [
                 "**/libs.versions.toml",
                 "**/build.gradle"
             ],
             "addLabels": [
                 "gradle"
-            ]
+            ],
+            "groupName": "gradle updates",
+            "groupSlug": "gradle-updates"
         },
         {
-            "matchFileNames": [
-                "**/pyproject.toml",
-                "**/poetry.lock"
+            "description": "Group Python/poetry dependency updates in a separate PR",
+            "matchManagers": [
+                "poetry",
+                "pep621"
             ],
+            "enabled": true,
             "addLabels": [
                 "platform"
+            ],
+            "groupName": "python updates",
+            "groupSlug": "python-updates"
+        },
+        {
+            "description": "Python interpreter version stays in a separate PR",
+            "matchManagers": [
+                "poetry",
+                "pep621"
+            ],
+            "matchPackageNames": [
+                "python"
+            ],
+            "groupName": "python version update",
+            "groupSlug": "python-version-update",
+            "addLabels": [
+                "python-version-update"
             ]
         },
         {

--- a/cloud-platform-squad.json
+++ b/cloud-platform-squad.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
         "github>SonarSource/renovate-config"
     ],


### PR DESCRIPTION
---
  Renovate configuration updates

  Schedule

  Changed from Thursday 9-11am to Sunday 10am-12pm.

  Dependency grouping

  Patch and minor updates are now grouped into consolidated PRs, reducing noise. Each ecosystem gets its own PR to keep changes reviewable:

  - Gradle (libs.versions.toml, build.gradle) → single gradle updates PR
  - Python/poetry dependencies → single python dependencies PR
  - Python interpreter version → individual PR (not grouped)
  - GitHub Actions → single github actions PR (unchanged)
  - Everything else — patch → single all patch updates PR
  - Everything else — minor → single all minor updates PR

  Python/poetry fix

  Switched from file-name matching to manager matching (poetry, pep621) to ensure updates are correctly detected. Added explicit enabled: true to override any potential
  disablement from the base config. pep621 was added to cover pyproject.toml files that don't use a [tool.poetry] section.