### PR TITLE
BUILD-10611 Group dependencies per manager in default Renovate preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Use manual rebasing only when needed (for example, merge conflicts, outdated bas
 #### Dependency grouping
 
 To reduce Renovate PR volume, the shared `default` preset groups updates by manager using `packageRules`.
-Manager-based groups currently include: `github-actions`, `maven`, `gradle` (including `gradle-wrapper`), `npm`, `poetry`, `pipenv`, `pip_requirements`, `nuget`, `dockerfile`, and `terraform`.
+Manager-based groups currently include: `github-actions`, `maven`, `gradle` (including `gradle-wrapper`), `npm`, `poetry`, `pipenv`, `pip_requirements`, `nuget`, `terraform`, `helmfile`, and `mise`.
 The preset also includes an additional non-manager grouping rule that groups all `mise` updates together.
 
 #### Authentication

--- a/README.md
+++ b/README.md
@@ -18,11 +18,20 @@ When a Renovate PR must be rebased, do it manually from the Renovate UI:
 
 Use manual rebasing only when needed (for example, merge conflicts, outdated base branch, or required checks that need a fresh branch).
 
+
 ### [`default`](default.json)
 
 ```json
   "extends": ["github>SonarSource/renovate-config"]
 ```
+
+#### Dependency grouping
+
+To reduce Renovate PR volume, the shared `default` preset groups updates by manager using `packageRules`.
+Manager-based groups currently include: `github-actions`, `maven`, `gradle` (including `gradle-wrapper`), `npm`, `poetry`, `pipenv`, `pip_requirements`, `nuget`, `dockerfile`, and `terraform`.
+The preset also includes an additional non-manager grouping rule that groups all `mise` updates together.
+
+#### Authentication
 
 Provides authentication credentials to https://repox.jfrog.io. The following package managers were tested for compatibility: `npm`, `maven`, `gradle`, `pipenv`, `poetry`, and `nuget`.
 
@@ -125,7 +134,7 @@ RunnerImage: "275878209202.dkr.ecr.eu-central-1.amazonaws.com/base:2024120112345
 
 ### [`languages-team`](languages-team.json)
 ```json
-  "extends": ["github>SonarSource/renovate-config:languates-team"]
+  "extends": ["github>SonarSource/renovate-config:languages-team"]
 ```
 
 Enables the `custom` manager for replacing version strings in `snapshot-generation.sh`.

--- a/default.json
+++ b/default.json
@@ -82,20 +82,28 @@
             "groupSlug": "nuget-dependencies"
         },
         {
-            "description": "Group Dockerfile updates",
-            "matchManagers": [
-                "dockerfile"
-            ],
-            "groupName": "Dockerfile dependencies",
-            "groupSlug": "dockerfile-dependencies"
-        },
-        {
             "description": "Group Terraform updates",
             "matchManagers": [
                 "terraform"
             ],
             "groupName": "Terraform dependencies",
             "groupSlug": "terraform-dependencies"
+        },
+        {
+            "description": "Group Helmfile updates",
+            "matchManagers": [
+                "helmfile"
+            ],
+            "groupName": "Helmfile dependencies",
+            "groupSlug": "helmfile-dependencies"
+        },
+        {
+            "description": "Group Mise tool updates",
+            "matchManagers": [
+                "mise"
+            ],
+            "groupName": "Mise tool dependencies",
+            "groupSlug": "mise-tool-dependencies"
         },
         {
             "matchDatasources": [

--- a/default.json
+++ b/default.json
@@ -17,6 +17,87 @@
             "rollbackPrs": true
         },
         {
+            "description": "Group GitHub Actions updates",
+            "matchManagers": [
+                "github-actions"
+            ],
+            "groupName": "GitHub Actions dependencies",
+            "groupSlug": "github-actions-dependencies"
+        },
+        {
+            "description": "Group Maven updates",
+            "matchManagers": [
+                "maven"
+            ],
+            "groupName": "Maven dependencies",
+            "groupSlug": "maven-dependencies"
+        },
+        {
+            "description": "Group Gradle updates",
+            "matchManagers": [
+                "gradle",
+                "gradle-wrapper"
+            ],
+            "groupName": "Gradle dependencies",
+            "groupSlug": "gradle-dependencies"
+        },
+        {
+            "description": "Group npm updates",
+            "matchManagers": [
+                "npm"
+            ],
+            "groupName": "npm dependencies",
+            "groupSlug": "npm-dependencies"
+        },
+        {
+            "description": "Group Poetry updates",
+            "matchManagers": [
+                "poetry"
+            ],
+            "groupName": "Poetry dependencies",
+            "groupSlug": "poetry-dependencies"
+        },
+        {
+            "description": "Group Pipenv updates",
+            "matchManagers": [
+                "pipenv"
+            ],
+            "groupName": "Pipenv dependencies",
+            "groupSlug": "pipenv-dependencies"
+        },
+        {
+            "description": "Group pip requirements updates",
+            "matchManagers": [
+                "pip_requirements"
+            ],
+            "groupName": "pip requirements dependencies",
+            "groupSlug": "pip-requirements-dependencies"
+        },
+        {
+            "description": "Group NuGet updates",
+            "matchManagers": [
+                "nuget"
+            ],
+            "groupName": "NuGet dependencies",
+            "groupSlug": "nuget-dependencies"
+        },
+        {
+            "description": "Group Dockerfile updates",
+            "matchManagers": [
+                "dockerfile"
+            ],
+            "groupName": "Dockerfile dependencies",
+            "groupSlug": "dockerfile-dependencies"
+        },
+        {
+            "description": "Group Terraform updates",
+            "matchManagers": [
+                "terraform"
+            ],
+            "groupName": "Terraform dependencies",
+            "groupSlug": "terraform-dependencies"
+        },
+        {
             "matchDatasources": [
                 "maven"
             ],


### PR DESCRIPTION
BUILD-10611
- add manager-based grouping packageRules in the default Renovate preset
- add `helmfile` and `mise` manager groups (validated locally)
- document default grouping behavior in README

## Local validation

Validated by running `renovate --platform=local LOG_LEVEL=debug` with the PR branch config against 3 real repos.

### `ci-ami-images`

8 updates → **4 grouped branches**:

| Branch | Manager | Contents |
|--------|---------|----------|
| `renovate/mise-tool-dependencies` | mise | poetry, pipx:ansible-lint 25.x, pipx:ansible 12.x |
| `renovate/major-mise-tool-dependencies` | mise | poetry 2.x, pipx:ansible-lint 26.x, pipx:ansible 13.x |
| `renovate/poetry-dependencies` | poetry | pytest minor/patch |
| `renovate/major-poetry-dependencies` | poetry | major pyproject.toml deps |

### `re-terraform-aws-vault`

15 updates → **6 grouped branches**:

| Branch | Manager | Contents |
|--------|---------|----------|
| `renovate/helmfile-dependencies` | helmfile | aws-load-balancer-controller 1.x, vault 0.x |
| `renovate/major-helmfile-dependencies` | helmfile | aws-load-balancer-controller → 3.x, datadog → 3.x |
| `renovate/mise-tool-dependencies` | mise | mise tool minor/patch updates |
| `renovate/major-mise-tool-dependencies` | mise | poetry → 2.x |
| `renovate/terraform-dependencies` | terraform | terraform-aws-modules minor/patch |
| `renovate/major-terraform-dependencies` | terraform | terraform-aws-modules major bumps |

### `ops-releasability`

9 updates → **4 grouped branches**:

| Branch | Manager | Contents |
|--------|---------|----------|
| `renovate/maven-dependencies` | maven | jackson-dataformat-xml, aws-sdk bom, mockito-core, maven-shade-plugin |
| `renovate/mise-tool-dependencies` | mise | java minor/patch |
| `renovate/major-mise-tool-dependencies` | mise | java major |
| `renovate/poetry-dependencies` | poetry | boto3, aws-cdk-lib, constructs |