### PR TITLE
BUILD-10858 Disable Renovate via default preset

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,5 +1,6 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "enabled": false,
     "extends": [
         "config:recommended",
         ":timezone(CET)",


### PR DESCRIPTION
## Summary

Sets `"enabled": false` in `default.json` so repositories extending `github>SonarSource/renovate-config` inherit org-wide Renovate off until re-enabled.

## Ticket

https://sonarsource.atlassian.net/browse/BUILD-10858

## Follow-up

- Re-enable (remove key or set `true`) when appropriate.
- Consider `minimumReleaseAge` for npm/pypi when turning back on.