### PR TITLE
BUILD-10860: Phase 3 - harden minimumReleaseAge enforcement

### DIFF
--- a/default.json
+++ b/default.json
@@ -109,6 +109,9 @@
         },
         {
             "description": "Skip minimumReleaseAge for internal SonarSource packages (trusted, published by us)",
+            "matchDatasources": [
+                "maven"
+            ],
             "matchPackagePatterns": [
                 "^org.sonarsource",
                 "^com.sonarsource"

--- a/default.json
+++ b/default.json
@@ -6,7 +6,7 @@
         ":disableRateLimiting"
     ],
     "minimumReleaseAge": "5 days",
-    "minimumReleaseAgeBehaviour": "timestamp-optional",
+    "minimumReleaseAgeBehaviour": "timestamp-required",
     "prCreation": "not-pending",
     "rebaseWhen": "never",
     "packageRules": [
@@ -106,6 +106,24 @@
             ],
             "groupName": "Mise tool dependencies",
             "groupSlug": "mise-tool-dependencies"
+        },
+        {
+            "description": "Skip minimumReleaseAge for internal SonarSource packages (trusted, published by us)",
+            "matchPackagePatterns": [
+                "^org.sonarsource",
+                "^com.sonarsource"
+            ],
+            "minimumReleaseAge": "0 days"
+        },
+        {
+            "description": "Skip minimumReleaseAge for internal SonarSource GitHub Actions",
+            "matchManagers": [
+                "github-actions"
+            ],
+            "matchPackagePatterns": [
+                "^SonarSource/"
+            ],
+            "minimumReleaseAge": "0 days"
         },
         {
             "matchDatasources": [

--- a/dev-infra-squad.json
+++ b/dev-infra-squad.json
@@ -34,26 +34,7 @@
             "^(github-action)(\\/[^/]+)?\\/action\\.ya?ml$"
         ]
     },
-    "minimumReleaseAgeBehaviour": "timestamp-required",
     "packageRules": [
-        {
-            "description": "Skip minimumReleaseAge for internal SonarSource packages (trusted, published by us)",
-            "matchPackagePatterns": [
-                "^org.sonarsource",
-                "^com.sonarsource"
-            ],
-            "minimumReleaseAge": "0 days"
-        },
-        {
-            "description": "Skip minimumReleaseAge for internal SonarSource GitHub Actions",
-            "matchManagers": [
-                "github-actions"
-            ],
-            "matchPackagePatterns": [
-                "^SonarSource/"
-            ],
-            "minimumReleaseAge": "0 days"
-        },
         {
             "matchPackagePatterns": [
                 ".*sonar-(ubuntu|windowsserver|amazon|centos)-.*"

--- a/dev-infra-squad.json
+++ b/dev-infra-squad.json
@@ -34,7 +34,26 @@
             "^(github-action)(\\/[^/]+)?\\/action\\.ya?ml$"
         ]
     },
+    "minimumReleaseAgeBehaviour": "timestamp-required",
     "packageRules": [
+        {
+            "description": "Skip minimumReleaseAge for internal SonarSource packages (trusted, published by us)",
+            "matchPackagePatterns": [
+                "^org.sonarsource",
+                "^com.sonarsource"
+            ],
+            "minimumReleaseAge": "0 days"
+        },
+        {
+            "description": "Skip minimumReleaseAge for internal SonarSource GitHub Actions",
+            "matchManagers": [
+                "github-actions"
+            ],
+            "matchPackagePatterns": [
+                "^SonarSource/"
+            ],
+            "minimumReleaseAge": "0 days"
+        },
         {
             "matchPackagePatterns": [
                 ".*sonar-(ubuntu|windowsserver|amazon|centos)-.*"


### PR DESCRIPTION
## What

Phase 3 of BUILD-10860: harden `minimumReleaseAge` enforcement org-wide.

Changes to `default.json`:

- Switch `minimumReleaseAgeBehaviour` from `"timestamp-optional"` to `"timestamp-required"` — external deps from registries without release timestamps are now blocked (previously silently allowed).
- Add exclusion rules (`minimumReleaseAge: "0 days"`) for:
  - Internal SonarSource Maven/Gradle packages (`org.sonarsource.*`, `com.sonarsource.*`) hosted in Repox
  - Internal SonarSource GitHub Actions (`SonarSource/*`)

Changes to `dev-infra-squad.json`:

- Remove Phase 3 overrides that were added for testing (now inherited from `default.json`)

## Why

Internal SonarSource packages are trusted and published by us — there is no reason to wait 5 days before updating them. The exclusions must be in place before switching to `timestamp-required`, since Repox (Artifactory) does not always provide release timestamps.

## Testing

Validated on `sonar-dummy` by [pointing its config at this branch](https://github.com/SonarSource/sonar-dummy/pull/577):
- Internal SonarSource deps (Maven + GitHub Actions) update without delay
- External deps with timestamps respect the 5-day minimum release age
- `mise` correctly shows pending newer versions held back by the release age

Tracking: [BUILD-10860](https://sonarsource.atlassian.net/browse/BUILD-10860)

[BUILD-10860]: https://sonarsource.atlassian.net/browse/BUILD-10860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ