### PR TITLE
BUILD-11023: Fix "core.hooksPath not permitted" error on dev-infra-squad repo scans

### DIFF
--- a/dev-infra-squad.json
+++ b/dev-infra-squad.json
@@ -3,7 +3,6 @@
     "extends": [
         "github>SonarSource/renovate-config",
         ":maintainLockFilesWeekly",
-        ":enablePreCommit",
         "docker:enableMajor",
         "docker:pinDigests"
     ],
@@ -26,6 +25,15 @@
     ],
     "dependencyDashboard": true,
     "configMigration": true,
+    "allowedPostUpgradeCommands": [
+        "^pre-commit autoupdate"
+    ],
+    "postUpgradeTasks": {
+        "commands": [
+            "pre-commit autoupdate --freeze || true"
+        ],
+        "executionMode": "branch"
+    },
     "addLabels": [
         "dependencies"
     ],


### PR DESCRIPTION
## What Changed?
- Move pre-commit off of failing `:enablePreCommit` and onto a postupgradetask for dev-infra-squad renovate configs
- This fixes errors regarding "`core.hooksPath` not permitted"

From Claude:

> The dev-infra-squad.json extends :enablePreCommit (line 6), which is a Renovate preset that configures core.hooksPath for pre-commit hook support. This is what simple-git is blocking.