### PR TITLE
BUILD-10967: set minimumReleaseAge=0 for runner base images

### DIFF
--- a/dev-infra-squad.json
+++ b/dev-infra-squad.json
@@ -69,6 +69,16 @@
             "groupSlug": "python-deps",
             "separateMinorPatch": false,
             "automerge": false
+        },
+        {
+            "description": "Skip minimumReleaseAge for SonarSource ECR runner base images (immediate updates)",
+            "matchDatasources": [
+                "docker"
+            ],
+            "matchPackagePatterns": [
+                "^275878209202\\.dkr\\.ecr\\.eu-central-1\\.amazonaws\\.com/"
+            ],
+            "minimumReleaseAge": "0 days"
         }
     ],
     "vulnerabilityAlerts": {


### PR DESCRIPTION
## Summary

- Adds a targeted `packageRules` entry in `dev-infra-squad.json` to set `minimumReleaseAge: "0 days"` for Docker images coming from the SonarSource ECR registry `275878209202.dkr.ecr.eu-central-1.amazonaws.com`.
- These are our internally-built GitHub runner base images (see the existing custom regex manager for `infra/applications/github-runners/values/config.yaml` in the same preset). They are trusted, published by us, and tagged with monotonic timestamps — we want Renovate to open update PRs as soon as a new tag is pushed rather than waiting for the global 5-day `minimumReleaseAge`.
- The rule is scoped to `matchDatasources: ["docker"]` + `matchPackagePatterns: ["^275878209202\\.dkr\\.ecr\\.eu-central-1\\.amazonaws\\.com/"]`, so it does not loosen behavior for any other Docker image or other managers.
- JIRA: [BUILD-10967](https://sonarsource.atlassian.net/browse/BUILD-10967)

## Test plan

- [ ] Merge and observe next Renovate run on `SonarSource/github-runners-infra`
- [ ] Verify a new runner base image tag in the ECR triggers an update PR immediately (no 5-day wait)
- [ ] Confirm non-ECR Docker images (e.g. public Docker Hub images) still respect the 5-day `minimumReleaseAge`

## Caveats

- After merge, there may be a short burst of Renovate PRs in `github-runners-infra` for ECR tags published within the last 5 days that were previously held back. This is expected and one-off.

[BUILD-10967]: https://sonarsource.atlassian.net/browse/BUILD-10967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ