### PR TITLE
Add an automation to prevent updates to incompatible versions of sonar-plugin-api

### DIFF
--- a/.github/workflows/update-plugin-api-constraint.yml
+++ b/.github/workflows/update-plugin-api-constraint.yml
@@ -1,0 +1,69 @@
+name: Update sonar-plugin-api allowedVersions
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly on Monday
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Fetch compatibility table and extract minimum version
+        id: extract
+        run: |
+          README=$(curl -sf https://raw.githubusercontent.com/SonarSource/sonar-plugin-api/master/README.md)
+
+          get_first_api_version() {
+            echo "$README" | awk -v section="$1" '
+              $0 ~ section { found=1; next }
+              found && /^\|[^-]/ && !/Plugin API/ {
+                n = split($0, a, "|")
+                v = a[3]; gsub(/^[[:space:]]+|[[:space:]]+$/, "", v)
+                print v; exit
+              }
+            '
+          }
+
+          SERVER_API=$(get_first_api_version "## SonarQube Server")
+          COMMUNITY_API=$(get_first_api_version "## SonarQube Community Build")
+          CLOUD_API=$(echo "$README" | grep -oP 'Current version: \K[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+')
+          IDE_API=$(get_first_api_version "## SonarQube for IDE")
+
+          MIN_VERSION=$(printf '%s\n' "$SERVER_API" "$COMMUNITY_API" "$CLOUD_API" "$IDE_API" | sort -V | head -1)
+          echo "min_version=$MIN_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Update sonar-plugin-api.json
+        run: |
+          MIN="${{ steps.extract.outputs.min_version }}"
+          cat > sonar-plugin-api.json << EOF
+          {
+              "\$schema": "https://docs.renovatebot.com/renovate-schema.json",
+              "packageRules": [
+                  {
+                      "description": "Prevent updates to versions greater than the minimum supported version of sonar-plugin-api",
+                      "matchManagers": [
+                          "maven",
+                          "gradle"
+                      ],
+                      "matchPackageNames": [
+                          "org.sonarsource.api.plugin:sonar-plugin-api*"
+                      ],
+                      "allowedVersions": "<= $MIN"
+                  }
+              ]
+          }
+          EOF
+
+      - name: Open PR if changed
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8
+        with:
+          commit-message: "chore: update sonar-plugin-api allowedVersions to <= ${{ steps.extract.outputs.min_version }}"
+          title: "chore: update sonar-plugin-api version cap to ${{ steps.extract.outputs.min_version }}"
+          body: |
+            Auto-updated based on the [sonar-plugin-api compatibility matrix](https://github.com/SonarSource/sonar-plugin-api?tab=readme-ov-file#compatibility).
+
+            New target version: `<= ${{ steps.extract.outputs.min_version }}`
+          branch: chore/update-plugin-api-constraint

--- a/.github/workflows/update-plugin-api-constraint.yml
+++ b/.github/workflows/update-plugin-api-constraint.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   update:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -15,6 +18,7 @@ jobs:
         id: extract
         run: |
           README=$(curl -sf https://raw.githubusercontent.com/SonarSource/sonar-plugin-api/master/README.md)
+          [ -n "$README" ] || { echo "Failed to fetch README"; exit 1; }
 
           get_first_api_version() {
             echo "$README" | awk -v section="$1" '
@@ -27,17 +31,40 @@ jobs:
             '
           }
 
+          validate_api_version() {
+            label="$1"
+            version="$2"
+
+            if [ -z "$version" ]; then
+              echo "Error: failed to extract ${label} version from sonar-plugin-api README" >&2
+              exit 1
+            fi
+
+            if ! printf '%s\n' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'; then
+              echo "Error: extracted ${label} version '${version}' does not match expected x.y.z.build format" >&2
+              exit 1
+            fi
+          }
+
           SERVER_API=$(get_first_api_version "## SonarQube Server")
           COMMUNITY_API=$(get_first_api_version "## SonarQube Community Build")
-          CLOUD_API=$(echo "$README" | grep -oP 'Current version: \K[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+')
+          CLOUD_API=$(echo "$README" | grep -oP 'Current version: \K[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | head -n 1)
           IDE_API=$(get_first_api_version "## SonarQube for IDE")
 
+          validate_api_version "SonarQube Server" "$SERVER_API"
+          validate_api_version "SonarQube Community Build" "$COMMUNITY_API"
+          validate_api_version "SonarQube Cloud" "$CLOUD_API"
+          validate_api_version "SonarQube for IDE" "$IDE_API"
+
           MIN_VERSION=$(printf '%s\n' "$SERVER_API" "$COMMUNITY_API" "$CLOUD_API" "$IDE_API" | sort -V | head -1)
+          [ -n "$MIN_VERSION" ] || { echo "Could not extract one or more API versions"; exit 1; }
           echo "min_version=$MIN_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Update sonar-plugin-api.json
+        env:
+          MIN_VERSION: ${{ steps.extract.outputs.min_version }}
         run: |
-          MIN="${{ steps.extract.outputs.min_version }}"
+          MIN="$MIN_VERSION"
           cat > sonar-plugin-api.json << EOF
           {
               "\$schema": "https://docs.renovatebot.com/renovate-schema.json",

--- a/languages-team.json
+++ b/languages-team.json
@@ -1,7 +1,8 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
-        "github>SonarSource/renovate-config"
+        "github>SonarSource/renovate-config",
+        "github>SonarSource/renovate-config:sonar-plugin-api"
     ],
     "schedule": [
         "at any time"

--- a/quality-abd-squad.json
+++ b/quality-abd-squad.json
@@ -48,17 +48,6 @@
         },
         {
             "matchManagers": [
-                "maven"
-            ],
-            "matchPackageNames": [
-                "org.sonarsource.api.plugin:sonar-plugin-api*"
-            ],
-            "groupName": "sonar-plugin-api",
-            "groupSlug": "sonar-plugin-api",
-            "prHeader": "**Before updating the plugin-api version, make sure to check the [compatibility matrix](https://github.com/SonarSource/sonar-plugin-api?tab=readme-ov-file#compatibility) and stick to the lowest denominator.**"
-        },
-        {
-            "matchManagers": [
                 "maven",
                 "regex"
             ],

--- a/sonar-plugin-api.json
+++ b/sonar-plugin-api.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "packageRules": [
+        {
+            "description": "Prevent updates to versions greater than the minimum supported version of sonar-plugin-api",
+            "matchManagers": [
+                "maven",
+                "gradle"
+            ],
+            "matchPackageNames": [
+                "org.sonarsource.api.plugin:sonar-plugin-api*"
+            ],
+            "allowedVersions": "<= 13.2.0.3137"
+        }
+    ]
+}


### PR DESCRIPTION
### Context :

For analyzers, the sonar-plugin-api version cannot simply track the latest release — it must stay within the range supported by all SonarQube products simultaneously, as defined in the [https://github.com/SonarSource/sonar-plugin-api?tab=readme-ov-file#compatibility](https://github.com/SonarSource/sonar-plugin-api?tab=readme-ov-file#compatibility).

This PR enforces that constraint automatically, so Renovate never proposes an update that would break compatibility.

### How it works :

Every Monday, a workflow:
  1. Fetches the sonar-plugin-api README and extracts the current plugin API version for each product using regex
  2. Selects the lowest version across all products as the cap
  3. Regenerates sonar-plugin-api.json with the new allowedVersions value
  4. Opens a PR if anything changed

### Known limitations :
  - Fragile extraction: parsing versions out of a Markdown table is inherently brittle. This is a direct consequence of the compatibility matrix living in a README; finding a better source of truth is out of scope.
  - Requires human review: someone needs to merge the auto-generated PRs. We need to define who. The cap is unlikely to change more than once a month, so the overhead is low, but a missed PR means sonar-plugin-api updates would be silently blocked indefinitely.
  - Broad scope: the constraint is applied at the languages-team.json level, which should only be used by analyzers. Any future consumer of that config would inherit a version constraint that may not apply to them.