### PR TITLE
PREQ-5494: Disable Renovate updates for gh-action-lt-backlog

### DIFF
--- a/default.json
+++ b/default.json
@@ -129,6 +129,13 @@
             "minimumReleaseAge": "0 days"
         },
         {
+            "description": "Do not update SonarSource Jira automation actions; use branch-version (@v2).",
+            "matchDepNames": [
+                "SonarSource/gh-action-lt-backlog/**"
+            ],
+            "enabled": false
+        },
+        {
             "matchDatasources": [
                 "maven"
             ],


### PR DESCRIPTION
## Summary

- Adds a `packageRule` to `default.json` that disables Renovate updates for `SonarSource/gh-action-lt-backlog/**`
- This prevents Renovate from bumping ~15 repos to commit SHAs, keeping them aligned on `@v2` branch-version
- Enables central fixes (SAML changes, config updates, etc.) to be delivered via `@v2` without per-repo re-pinning

**JIRA:** [PREQ-5494](https://sonarsource.atlassian.net/browse/PREQ-5494)

## Test plan

- [ ] Verify `default.json` passes JSON validation
- [ ] Confirm the new rule is correctly placed in `packageRules`
- [ ] After merge, verify Renovate no longer opens PRs to bump `gh-action-lt-backlog` to commit SHAs in consuming repos

[PREQ-5494]: https://sonarsource.atlassian.net/browse/PREQ-5494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ