### PR TITLE
fix(cdk): use owner-id filter for AMI lookups in cdk.context.json

### DIFF
--- a/dev-infra-squad.json
+++ b/dev-infra-squad.json
@@ -118,11 +118,11 @@
                 "^cdk\\.context\\.json$"
             ],
             "matchStrings": [
-                ".*[\\\"|\"]ami:account=[0-9]{12}:filters\\.image-type\\.0=(?<imageType>.*?):filters\\.name\\.0=(?<imageName>.*?):.*[\\\"|\"]:[ ]*?[\\\"|\"]?(?<currentValue>ami-[a-z0-9]{17})[\\\"|\"]?"
+                ".*[\\\"|\"]ami:account=(?<account>[0-9]{12}):filters\\.image-type\\.0=(?<imageType>.*?):filters\\.name\\.0=(?<imageName>.*?):.*[\\\"|\"]:[ ]*?[\\\"|\"]?(?<currentValue>ami-[a-z0-9]{17})[\\\"|\"]?"
             ],
             "datasourceTemplate": "aws-machine-image",
             "versioningTemplate": "aws-machine-image",
-            "packageNameTemplate": "[{\"Name\":\"name\",\"Values\":[\"{{{imageName}}}\"]},{\"Name\":\"state\",\"Values\":[\"available\"]},{\"Name\":\"image-type\",\"Values\":[\"{{{imageType}}}\"]},{\"Name\":\"is-public\",\"Values\":[\"false\"]}]",
+            "packageNameTemplate": "[{\"Name\":\"name\",\"Values\":[\"{{{imageName}}}\"]},{\"Name\":\"state\",\"Values\":[\"available\"]},{\"Name\":\"image-type\",\"Values\":[\"{{{imageType}}}\"]},{\"Name\":\"owner-id\",\"Values\":[\"{{{account}}}\"]}]",
             "depNameTemplate": "{{{replace ' \\*' '' imageName}}}"
         },
         {


### PR DESCRIPTION
## Problem

Renovate reported `no-result` when looking up AMIs referenced in `cdk.context.json`. The custom manager built a filter using `is-public: false` but never captured or passed the AWS account ID from the context key.

Without knowing which account owns the AMIs, Renovate queried its own AWS account and found nothing — the AMIs are private and belong to specific Sonar accounts.

## Fix

- Capture the account number from the `ami:account=<id>:...` key via a new `(?<account>[0-9]{12})` capture group
- Replace the `is-public: false` filter with `owner-id: <account>`, which directly scopes the lookup to the correct AWS account