### PR TITLE
fix(cdk): filter by platform in cdk.context.json AMI lookup

### DIFF
--- a/dev-infra-squad.json
+++ b/dev-infra-squad.json
@@ -118,11 +118,11 @@
                 "^cdk\\.context\\.json$"
             ],
             "matchStrings": [
-                ".*[\\\"|\"]ami:account=(?<account>[0-9]{12}):filters\\.image-type\\.0=(?<imageType>.*?):filters\\.name\\.0=(?<imageName>.*?):.*[\\\"|\"]:[ ]*?[\\\"|\"]?(?<currentValue>ami-[a-z0-9]{17})[\\\"|\"]?"
+                ".*[\\\"|\"]ami:account=(?<account>[0-9]{12}):filters\\.image-type\\.0=(?<imageType>.*?):filters\\.name\\.0=(?<imageName>.*?):filters\\.platform\\.0=(?<platform>.*?):.*[\\\"|\"]:[ ]*?[\\\"|\"]?(?<currentValue>ami-[a-z0-9]{17})[\\\"|\"]?"
             ],
             "datasourceTemplate": "aws-machine-image",
             "versioningTemplate": "aws-machine-image",
-            "packageNameTemplate": "[{\"Name\":\"name\",\"Values\":[\"{{{imageName}}}\"]},{\"Name\":\"state\",\"Values\":[\"available\"]},{\"Name\":\"image-type\",\"Values\":[\"{{{imageType}}}\"]},{\"Name\":\"owner-id\",\"Values\":[\"{{{account}}}\"]}]",
+            "packageNameTemplate": "[{\"Name\":\"name\",\"Values\":[\"{{{imageName}}}\"]},{\"Name\":\"state\",\"Values\":[\"available\"]},{\"Name\":\"image-type\",\"Values\":[\"{{{imageType}}}\"]},{\"Name\":\"owner-id\",\"Values\":[\"{{{account}}}\"]},{\"Name\":\"platform\",\"Values\":[\"{{{platform}}}\"]}]",
             "depNameTemplate": "{{{replace ' \\*' '' imageName}}}"
         },
         {

--- a/dev-infra-squad.json
+++ b/dev-infra-squad.json
@@ -118,11 +118,11 @@
                 "^cdk\\.context\\.json$"
             ],
             "matchStrings": [
-                ".*[\\\"|\"]ami:account=[0-9]{12}:filters\\.image-type\\.0=(?<imageType>.*?):filters\\.name\\.0=(?<imageName>.*?):.*[\\\"|\"]:[ ]*?[\\\"|\"]?(?<currentValue>ami-[a-z0-9]{17})[\\\"|\"]?"
+                ".*[\\\"|\"]ami:account=(?<account>[0-9]{12}):filters\\.image-type\\.0=(?<imageType>.*?):filters\\.name\\.0=(?<imageName>.*?):.*[\\\"|\"]:[ ]*?[\\\"|\"]?(?<currentValue>ami-[a-z0-9]{17})[\\\"|\"]?"
             ],
             "datasourceTemplate": "aws-machine-image",
             "versioningTemplate": "aws-machine-image",
-            "packageNameTemplate": "[{\"Name\":\"name\",\"Values\":[\"{{{imageName}}}\"]},{\"Name\":\"state\",\"Values\":[\"available\"]},{\"Name\":\"image-type\",\"Values\":[\"{{{imageType}}}\"]},{\"Name\":\"is-public\",\"Values\":[\"false\"]}]",
+            "packageNameTemplate": "[{\"Name\":\"name\",\"Values\":[\"{{{imageName}}}\"]},{\"Name\":\"state\",\"Values\":[\"available\"]},{\"Name\":\"image-type\",\"Values\":[\"{{{imageType}}}\"]},{\"Name\":\"owner-id\",\"Values\":[\"{{{account}}}\"]}]",
             "depNameTemplate": "{{{replace ' \\*' '' imageName}}}"
         },
         {


### PR DESCRIPTION
## Problem

PR #124 added `owner-id` filtering but the lookup is still failing with `no-result`.

EngXP suggested also capturing and filtering by `platform` (e.g. `windows`), which is already present in the `cdk.context.json` key but was previously ignored.

## Changes

- Extend the regex to capture `(?<platform>.*?)` from the `filters.platform.0=` segment
- Add `{"Name":"platform","Values":["{{{platform}}}"]}` to the `packageNameTemplate`

This ensures the AMI lookup exactly matches the filters encoded in the context key.