### PR TITLE
SC-49235 Fix renovate for sonarcloud-users

### DIFF
--- a/default.json
+++ b/default.json
@@ -136,6 +136,16 @@
             "enabled": false
         },
         {
+            "description": "Do not update private SonarSource reusable workflows inaccessible to Renovate.",
+            "matchDepNames": [
+                "SonarSource/sonarqube-cloud-github-actions",
+                "SonarSource/sonarqube-cloud-github-actions/**",
+                "SonarSource/sqc-e2e-tests",
+                "SonarSource/sqc-e2e-tests/**"
+            ],
+            "enabled": false
+        },
+        {
             "matchDatasources": [
                 "maven"
             ],


### PR DESCRIPTION
This should fix:

<img width="1238" height="444" alt="image" src="https://github.com/user-attachments/assets/7f210aa2-6583-4045-9949-dadf69386037" />


----
## Summary by Gitar

- **Renovate Configuration:**
  - Added package rule to disable updates for private SonarSource workflows `SonarSource/sonarqube-cloud-github-actions` and `SonarSource/sqc-e2e-tests` to prevent Renovate errors.

<sub>This will update automatically on new commits.</sub>