### PR TITLE
BUILD-11448 Set rebaseWhen to conflicted org-wide

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,23 @@
 
 ## Rebase policy
 
-The organization defaults to manual rebasing by setting `rebaseWhen` to `never` in the shared `default` preset.
-This avoids large CI spikes when many Renovate PRs are open.
+The shared `default` preset sets `rebaseWhen` to `conflicted`. With this policy, Renovate:
 
-When a Renovate PR must be rebased, do it manually from the Renovate UI:
+- **Rebases on conflict** -- automatically rebases a PR branch when a merge
+  conflict with the default branch is detected.
+- **Does not rebase on every base-branch update** -- avoids rebasing every time the
+  default branch moves forward, which limits CI spikes when many Renovate PRs are
+  open.
+
+Renovate still updates open PRs when newer dependency versions are released; that
+behavior is independent of `rebaseWhen`.
+
+If a manual rebase is still needed, use the Renovate UI:
 
 1. Open [developer.mend.io](https://developer.mend.io/) and log in with GitHub.
 2. Select the `Renovate` app (not `Forking Renovate`).
 3. Open your repository and the target Renovate PR.
 4. Trigger a manual rebase from the UI (Rebase action).
-
-Use manual rebasing only when needed (for example, merge conflicts, outdated base branch, or required checks that need a fresh branch).
-
 
 ### [`default`](default.json)
 

--- a/cloud-platform-squad.json
+++ b/cloud-platform-squad.json
@@ -10,7 +10,7 @@
     "labels": [
         "dependency-update"
     ],
-    "rebaseWhen": "never",
+    "rebaseWhen": "conflicted",
     "packageRules": [
         {
             "description": "Group all patch updates in a single PR",

--- a/default.json
+++ b/default.json
@@ -8,7 +8,7 @@
     "minimumReleaseAge": "5 days",
     "minimumReleaseAgeBehaviour": "timestamp-required",
     "prCreation": "not-pending",
-    "rebaseWhen": "never",
+    "rebaseWhen": "conflicted",
     "allowedPostUpgradeCommands": [
         "^pre-commit autoupdate( --freeze)?( \\|\\| true)?$",
         "^\\./gradlew [^;&|]{0,500}--write-locks[^;&|]{0,500}$",

--- a/dev-infra-squad.json
+++ b/dev-infra-squad.json
@@ -7,7 +7,6 @@
         "docker:pinDigests"
     ],
     "timezone": "Europe/Paris",
-    "rebaseWhen": "conflicted",
     "schedule": [
         "after 7am every weekday",
         "before 8pm every weekday"

--- a/organization-reporting-squad.json
+++ b/organization-reporting-squad.json
@@ -4,7 +4,7 @@
         "github>SonarSource/renovate-config"
     ],
     "timezone": "US/Central",
-    "rebaseWhen": "never",
+    "rebaseWhen": "conflicted",
     "schedule": [
         "* 7-15 * * 1"
     ],


### PR DESCRIPTION
## Summary

Change the default Renovate rebase policy from `"never"` to `"conflicted"` across the organization so that Renovate:

- **Rebases on conflict** by automatically rebasing a PR branch when a merge conflict with the default branch is detected.
- **Does not rebase on every base-branch update**, limiting CI spikes when many Renovate PRs are open.

Renovate still updates open PRs when newer dependency versions are released; that behavior is independent of `rebaseWhen`.

## Changes

| File | Change |
|------|--------|
| `default.json` | `"never"` → `"conflicted"` |
| `dev-infra-squad.json` | Removed redundant explicit `rebaseWhen: "conflicted"` override (inherits new default) |
| `cloud-platform-squad.json` | `"never"` → `"conflicted"` (explicit override kept) |
| `organization-reporting-squad.json` | `"never"` → `"conflicted"` (explicit override kept) |
| `README.md` | Updated "Rebase policy" section to document new behavior |

`ide-xp-team.json` and `quality-abd-squad.json` already had `"conflicted"` and are left unchanged.

## References

- Discuss: https://discuss.sonarsource.com/t/update-renovate-now-rebases-dependency-prs-on-merge-conflict/24260
- Jira: [BUILD-11448](https://sonarsource.atlassian.net/browse/BUILD-11448)
- Renovate docs: [`rebaseWhen`](https://docs.renovatebot.com/configuration-options/#rebasewhen)

[BUILD-11448]: https://sonarsource.atlassian.net/browse/BUILD-11448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ