### PR TITLE
BUILD-11448 Set rebaseWhen to conflicted in dev-infra-squad preset

### DIFF
--- a/dev-infra-squad.json
+++ b/dev-infra-squad.json
@@ -7,7 +7,7 @@
         "docker:pinDigests"
     ],
     "timezone": "Europe/Paris",
-    "rebaseWhen": "never",
+    "rebaseWhen": "conflicted",
     "schedule": [
         "after 7am every weekday",
         "before 8pm every weekday"


### PR DESCRIPTION
## Summary

Change `rebaseWhen` from `"never"` to `"conflicted"` in the `dev-infra-squad` preset so Renovate automatically rebases PRs when a merge conflict is detected.

## References

- Jira: [BUILD-11448](https://sonarsource.atlassian.net/browse/BUILD-11448)
- Renovate docs: [`rebaseWhen`](https://docs.renovatebot.com/configuration-options/#rebasewhen)

[BUILD-11448]: https://sonarsource.atlassian.net/browse/BUILD-11448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ