### PR TITLE
BUILD-11526 Skip minimumReleaseAge for aws-machine-image updates

### DIFF
--- a/dev-infra-squad.json
+++ b/dev-infra-squad.json
@@ -79,6 +79,13 @@
                 "^275878209202\\.dkr\\.ecr\\.eu-central-1\\.amazonaws\\.com/"
             ],
             "minimumReleaseAge": "0 days"
+        },
+        {
+            "description": "Skip minimumReleaseAge for EC2 AMI updates",
+            "matchDatasources": [
+                "aws-machine-image"
+            ],
+            "minimumReleaseAge": "0 days"
         }
     ],
     "vulnerabilityAlerts": {


### PR DESCRIPTION
## Summary

- Add a `dev-infra-squad` `packageRule` with `minimumReleaseAge: 0 days` for all `aws-machine-image` dependencies.
- Avoids the 5-day delay from `default.json` after prod AMIs are promoted (e.g. `dotnet-infra` / `dotnet-bubble-ci-v*` in `cdk.context.json`).

## Jira

BUILD-11526

## Test plan

- [ ] Merge and wait for Renovate on `dotnet-infra` (or re-run `ci-aws-infra` renovate workflow).
- [ ] Confirm Dependency Dashboard no longer holds AMI updates for `minimumReleaseAge` 