### PR TITLE
Set minimumReleaseAgeBehaviour to timestamp-optional for organization-reporting-squad

### DIFF
--- a/organization-reporting-squad.json
+++ b/organization-reporting-squad.json
@@ -20,6 +20,7 @@
     "addLabels": [
         "dependencies"
     ],
+    "minimumReleaseAgeBehaviour": "timestamp-optional",
     "draftPR": false,
     "packageRules": [
         {


### PR DESCRIPTION
## Summary
- Adds `minimumReleaseAgeBehaviour: "timestamp-optional"` at the top level of the organization-reporting-squad config so it applies to all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)