### PR TITLE
BUILD-11669 Allow pre-commit autoupdate as a post-upgrade command

### DIFF
--- a/default.json
+++ b/default.json
@@ -10,9 +10,9 @@
     "prCreation": "not-pending",
     "rebaseWhen": "never",
     "allowedPostUpgradeCommands": [
-        "^pre-commit autoupdate",
-        "^\\.\/gradlew .{0,500}--write-locks.{0,500}$",
-        "^dotnet restore .{0,200}$",
+        "^pre-commit autoupdate( --freeze)?( \\|\\| true)?$",
+        "^\\./gradlew [^;&|]{0,500}--write-locks[^;&|]{0,500}$",
+        "^dotnet restore [^;&|]{0,200}$",
         "^bun install$"
     ],
     "packageRules": [

--- a/default.json
+++ b/default.json
@@ -10,7 +10,10 @@
     "prCreation": "not-pending",
     "rebaseWhen": "never",
     "allowedPostUpgradeCommands": [
-        "^pre-commit autoupdate"
+        "^pre-commit autoupdate",
+        "^\\.\/gradlew .{0,500}--write-locks.{0,500}$",
+        "^dotnet restore .{0,200}$",
+        "^bun install$"
     ],
     "packageRules": [
         {

--- a/default.json
+++ b/default.json
@@ -9,6 +9,9 @@
     "minimumReleaseAgeBehaviour": "timestamp-required",
     "prCreation": "not-pending",
     "rebaseWhen": "never",
+    "allowedPostUpgradeCommands": [
+        "^pre-commit autoupdate"
+    ],
     "packageRules": [
         {
             "matchDepTypes": [


### PR DESCRIPTION
## Summary

- Consolidates `allowedPostUpgradeCommands` from team presets into `default.json`
- `allowedPostUpgradeCommands` is a global-scope Renovate setting silently ignored in presets — it must be in the base config at the global level
- Without this, `postUpgradeTasks` commands defined in `dev-infra-squad` and `ide-xp-team` presets fail with: _"Post-upgrade command has not been added to the allowed list in allowedCommands"_

**Patterns consolidated from presets:**
| Preset | Command pattern |
|--------|----------------|
| `dev-infra-squad` | `^pre-commit autoupdate` |
| `ide-xp-team` | `^\.\/gradlew .{0,500}--write-locks.{0,500}$` |
| `ide-xp-team` | `^dotnet restore .{0,200}$` |
| `ide-xp-team` | `^bun install$` |

## Related

- https://github.com/SonarSource/ci-github-actions/pull/282
- https://sonarsource.atlassian.net/browse/BUILD-11669
- https://github.com/SonarSource/ci-github-actions/pull/312