### PR TITLE
BUILD-10065: Remove cirrus-modules Renovate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,20 +90,6 @@ Replaces version strings in `cdk.context.json` files. Works
 with [LookupMachineImage](https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_ec2/LookupMachineImage.html). Only the `name` parameter
 is used by the manager. Any additional parameters such as `filters` are ignored.
 
-#### Cirrus CI modules in the main Starlark files
-
-Replaces Cirrus CI modules version or digest strings in `.cirrus.star` and `lib.star` files.
-
-##### Example
-
-```starlark
-# renovate: datasource=github-releases depName=SonarSource/cirrus-modules
-load("github.com/SonarSource/cirrus-modules@2.9.0", "load_features")
-
-# renovate: datasource=github-releases depName=SonarSource/cirrus-modules
-load("github.com/SonarSource/cirrus-modules@54babd3268dd6daf42ad877100789169a14e5fb3", "load_features")  # 2.9.0
-```
-
 #### ghcr.io Docker images in Cirrus CI YAML file
 
 Replaces ghcr.io Docker images version in `.cirrus.yaml`, `.cirrus.yml`.

--- a/dev-infra-squad.json
+++ b/dev-infra-squad.json
@@ -143,15 +143,6 @@
         },
         {
             "customType": "regex",
-            "fileMatch": [
-                "^\\.cirrus\\.star$"
-            ],
-            "matchStrings": [
-                "datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n.*load.*\"github.com\\/.*@(?<currentDigest>[a-f0-9]+)\",.* # (?<currentValue>.*)"
-            ]
-        },
-        {
-            "customType": "regex",
             "comment": "Match legacy depName and new packageName parameters",
             "fileMatch": [
                 ".*\\.sh$",


### PR DESCRIPTION
## Summary
- Remove the `.cirrus.star` regex manager from `dev-infra-squad.json` that updated cirrus-modules versions
- Remove the "Cirrus CI modules" README section and examples

## Context
Part of archiving `SonarSource/cirrus-modules` as part of Cirrus CI offboarding.

## Test plan
- [ ] Verify `dev-infra-squad.json` remains valid JSON
- [ ] Confirm no remaining `cirrus-modules` references in renovate-config