### PR TITLE
PREQ-6701: Fix NuGet minimumReleaseAge for Repox registries

### DIFF
--- a/default.json
+++ b/default.json
@@ -135,6 +135,26 @@
             "minimumReleaseAge": "0 days"
         },
         {
+            "description": "Skip minimumReleaseAge for internal SonarSource NuGet registries in Repox",
+            "matchDatasources": [
+                "nuget"
+            ],
+            "matchRegistryUrls": [
+                "**/sonarsource-nuget-*/**"
+            ],
+            "minimumReleaseAge": "0 days"
+        },
+        {
+            "description": "Fetch NuGet release timestamps from nuget.org; Repox proxy does not expose published",
+            "matchDatasources": [
+                "nuget"
+            ],
+            "registryUrls": [
+                "https://api.nuget.org/v3/index.json",
+                "https://repox.jfrog.io/artifactory/api/nuget/v3/nuget/index.json"
+            ]
+        },
+        {
             "description": "Do not update SonarSource Jira automation actions; use branch-version (@v2).",
             "matchDepNames": [
                 "SonarSource/gh-action-lt-backlog/**"

--- a/default.json
+++ b/default.json
@@ -149,9 +149,14 @@
             "matchDatasources": [
                 "nuget"
             ],
+            "matchRegistryUrls": [
+                "**/artifactory/api/nuget/v3/nuget/**",
+                "**/artifactory/api/nuget/nuget"
+            ],
             "registryUrls": [
                 "https://api.nuget.org/v3/index.json",
-                "https://repox.jfrog.io/artifactory/api/nuget/v3/nuget/index.json"
+                "https://repox.jfrog.io/artifactory/api/nuget/v3/nuget/index.json",
+                "https://repox.jfrog.io/artifactory/api/nuget/nuget"
             ]
         },
         {


### PR DESCRIPTION
## Summary
- Prepend `api.nuget.org` in the shared NuGet `packageRule` so Renovate can read `published` timestamps for packages resolved via the Repox public `nuget` proxy.
- Exempt internal `sonarsource-nuget-*` Repox NuGet registries from the 5-day `minimumReleaseAge` policy using `matchRegistryUrls`.

## Test plan
- [ ] Merge and verify on a NuGet Renovate repo (e.g. `sonar-scanner-msbuild`) via Mend debug logs
- [ ] Confirm external deps show `releaseTimestamp` in `packageFiles with updates`
- [ ] Confirm internal-feed deps (`sonarsource-nuget-releases` / `sonarsource-nuget-public`) are not stuck in "Awaiting Schedule"