### PR TITLE
PREQ-6794: Add npm hostRule for Repox Yarn authentication

### DIFF
--- a/default.json
+++ b/default.json
@@ -215,6 +215,12 @@
             "matchHost": "repox.jfrog.io",
             "username": "renovate-read",
             "password": "{{ secrets.REPOX_TOKEN }}"
+        },
+        {
+            "hostType": "npm",
+            "matchHost": "repox.jfrog.io",
+            "username": "renovate-read",
+            "password": "{{ secrets.REPOX_TOKEN }}"
         }
     ],
     "customManagers": [


### PR DESCRIPTION
## Summary

- Add an npm-specific `hostRule` for `repox.jfrog.io` in the shared `default` preset, matching the existing pypi and nuget patterns
- Enables Renovate to authenticate against Repox for Yarn/npm dependency lookups and `yarn.lock` artifact updates

## Context

Yarn repos like `SonarSource/code-quality-io` route all packages through Repox. Renovate does not read `npmRegistries` from `.yarnrc.yml` for lookups or lockfile updates — it requires manager-specific `hostRules`. Without `hostType: "npm"`, Renovate PRs open with version bumps but fail to update `yarn.lock`.

Validated locally via dry-run against `code-quality-io` package files (13 updates / 12 branches when credentials match).

## Test plan

- [ ] Merge and retry Renovate PRs on `SonarSource/code-quality-io` (#408, #409)
- [ ] Confirm `yarn.lock` artifact updates succeed and CI passes