### PR TITLE
BUILD-11729 Fix runner image Renovate updates

### DIFF
--- a/dev-infra-squad.json
+++ b/dev-infra-squad.json
@@ -85,6 +85,16 @@
                 "aws-machine-image"
             ],
             "minimumReleaseAge": "0 days"
+        },
+        {
+            "description": "Skip minimumReleaseAge for GitHub Actions runner base image updates",
+            "matchDatasources": [
+                "docker"
+            ],
+            "matchPackageNames": [
+                "ghcr.io/actions/actions-runner"
+            ],
+            "minimumReleaseAge": "0 days"
         }
     ],
     "vulnerabilityAlerts": {
@@ -142,7 +152,7 @@
         },
         {
             "customType": "regex",
-            "comment": "Match legacy depName and new packageName parameters",
+            "description": "Match legacy depName and new packageName parameters",
             "fileMatch": [
                 ".*\\.sh$",
                 ".*\\.?Dockerfile"


### PR DESCRIPTION
BUILD-11729 Fix runner image Renovate updates

## Purpose

Allow Renovate to create update PRs for the GitHub Actions runner base image even when the container registry metadata does not expose release timestamps.

## Changes

- Add a `dev-infra-squad` package rule for `ghcr.io/actions/actions-runner` that skips `minimumReleaseAge` for Docker updates.
- Replace an invalid custom manager `comment` field with `description` so the preset validates with the current Renovate schema.
- Preserve the latest `master` EC2 AMI `minimumReleaseAge` exception while rebasing.

## Validation

- `pre-commit run check-renovate --all-files`
- `pre-commit run check-json --all-files`
- `pre-commit run pretty-format-json --all-files`
- `npx --yes --package renovate renovate-config-validator dev-infra-squad.json`

## Breaking changes

None.
