### PR TITLE
PREQ-7124 Add quality-corelang-squad preset

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,4 +7,5 @@
 # squad configuration files
 organization-reporting-squad.json @sonarsource/orchestration-reporting-squad
 quality-abd-squad.json @sonarsource/quality-abd-squad
+quality-corelang-squad.json @sonarsource/code-quality-core-languages-parsers-squad
 quality-jvm-squad.json @sonarsource/quality-jvm-squad

--- a/README.md
+++ b/README.md
@@ -142,6 +142,13 @@ export KOTLIN_VERSION=2.15.0.2579
 - after the `export` directive use a descriptive variable name for storing the release version. The version number in the format
   of `MAJOR.MINOR.PATCH.BUILD` and is managed by Renovate.
 
+### [`quality-corelang-squad`](quality-corelang-squad.json)
+```json
+  "extends": ["github>SonarSource/renovate-config:quality-corelang-squad"]
+```
+
+Shared preset for Core Languages & Parsers repositories. It keeps immediate Renovate PR creation and `rebaseWhen: "never"`, limits enabled managers to the ones used across the squad repositories, disables grouping by default, and leaves `SonarSource/*` GitHub Actions on floating major refs such as `@v3`.
+
 ## Development
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -147,7 +147,17 @@ export KOTLIN_VERSION=2.15.0.2579
   "extends": ["github>SonarSource/renovate-config:quality-corelang-squad"]
 ```
 
-Shared preset for Core Languages & Parsers repositories. It keeps immediate Renovate PR creation and `rebaseWhen: "never"`, limits enabled managers to the ones used across the squad repositories, disables grouping by default, and leaves `SonarSource/*` GitHub Actions on floating major refs such as `@v3`.
+Shared preset for Core Languages & Parsers repositories. It extends the shared `default` preset, keeps `minimumReleaseAgeBehaviour: "timestamp-optional"`, creates PRs immediately, keeps `rebaseWhen: "never"`, adds the `dependencies` label, and enables only `github-actions`, `maven`, `nuget`, `gradle`, `gradle-wrapper`, `npm`, `cargo`, `dockerfile`, `pre-commit`, and `mise`.
+
+On top of the shared default behavior, it:
+
+- disables grouping by default
+- leaves `SonarSource/**` GitHub Actions on floating major refs such as `@v3`
+- groups MSTest dependencies, including `Verify.MSTest`
+- groups `Google.Protobuf` with `Grpc.Tools`
+- keeps `FluentAssertions` below `8.0.0`
+- groups Sonar parent POM updates
+- groups Roslyn dependencies
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ On top of the shared default behavior, it:
 - leaves `SonarSource/**` GitHub Actions on floating major refs such as `@v3`
 - groups MSTest dependencies, including `Verify.MSTest`
 - groups `Google.Protobuf` with `Grpc.Tools`
-- keeps `FluentAssertions` below `8.0.0`
+- keeps `FluentAssertions` below `8.0.0` due to change to paid license
 - groups Sonar parent POM updates
 - groups Roslyn dependencies
 

--- a/quality-corelang-squad.json
+++ b/quality-corelang-squad.json
@@ -91,7 +91,7 @@
         "nuget"
       ],
       "matchPackageNames": [
-        "Microsoft.CodeAnalysis.*"
+        "Microsoft.CodeAnalysis*"
       ],
       "groupName": "Roslyn"
     }

--- a/quality-corelang-squad.json
+++ b/quality-corelang-squad.json
@@ -1,43 +1,99 @@
 {
-    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "description": "Shared Renovate preset for Core Languages & Parsers repositories.",
-    "extends": [
-        "github>SonarSource/renovate-config"
-    ],
-    "minimumReleaseAgeBehaviour": "timestamp-optional",
-    "prCreation": "immediate",
-    "rebaseWhen": "never",
-    "addLabels": [
-        "dependencies"
-    ],
-    "enabledManagers": [
-        "github-actions",
-        "maven",
-        "nuget",
-        "gradle",
-        "gradle-wrapper",
-        "npm",
-        "cargo",
-        "pre-commit",
-        "mise"
-    ],
-    "packageRules": [
-        {
-            "description": "Don't group updates by default",
-            "matchPackageNames": [
-                "*"
-            ],
-            "groupName": null
-        },
-        {
-            "description": "Do not update SonarSource GitHub Actions so repositories can stay on branch versions such as @v3.",
-            "matchManagers": [
-                "github-actions"
-            ],
-            "matchDepNames": [
-                "SonarSource/**"
-            ],
-            "enabled": false
-        }
-    ]
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Shared Renovate preset for Core Languages & Parsers repositories.",
+  "extends": [
+    "local>SonarSource/renovate-config"
+  ],
+  "minimumReleaseAgeBehaviour": "timestamp-optional",
+  "prCreation": "immediate",
+  "rebaseWhen": "never",
+  "addLabels": [
+    "dependencies"
+  ],
+  "enabledManagers": [
+    "github-actions",
+    "maven",
+    "nuget",
+    "gradle",
+    "gradle-wrapper",
+    "npm",
+    "cargo",
+    "dockerfile",
+    "pre-commit",
+    "mise"
+  ],
+  "packageRules": [
+    {
+      "description": "Don't group updates by default",
+      "matchPackageNames": [
+        "*"
+      ],
+      "groupName": null
+    },
+    {
+      "description": "Do not update SonarSource GH actions, we want the branch-version. Only external actions must have commit ID.",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchDepNames": [
+        "SonarSource/**"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Group MSTest dependencies into a single PR",
+      "matchManagers": [
+        "nuget"
+      ],
+      "matchPackageNames": [
+        "MSTest.**",
+        "Microsoft.NET.Test.Sdk",
+        "Verify.MSTest"
+      ],
+      "groupName": "MSTest"
+    },
+    {
+      "description": "Group protobuf packages together - Grpc.Tools bundles protoc which must be compatible with the Google.Protobuf runtime",
+      "matchManagers": [
+        "nuget"
+      ],
+      "matchPackageNames": [
+        "Google.Protobuf",
+        "Grpc.Tools"
+      ],
+      "groupName": "protobuf"
+    },
+    {
+      "description": "Do not update FluentAssertions above v7 due to license change",
+      "matchManagers": [
+        "nuget"
+      ],
+      "matchPackageNames": [
+        "FluentAssertions"
+      ],
+      "allowedVersions": "<8.0.0"
+    },
+    {
+      "description": "Group parent POM updates into a single PR",
+      "matchManagers": [
+        "maven"
+      ],
+      "matchPackageNames": [
+        "org.sonarsource.parent:parent",
+        "com.sonarsource.parent:parent"
+      ],
+      "groupName": "Parent",
+      "groupSlug": "parent"
+    },
+    {
+      "description": "Group Roslyn dependencies into a single PR",
+      "matchManagers": [
+        "nuget"
+      ],
+      "matchPackageNames": [
+        "Microsoft.CodeAnalysis.*"
+      ],
+      "groupName": "Roslyn"
+    }
+  ]
 }

--- a/quality-corelang-squad.json
+++ b/quality-corelang-squad.json
@@ -1,99 +1,99 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "description": "Shared Renovate preset for Core Languages & Parsers repositories.",
-  "extends": [
-    "local>SonarSource/renovate-config"
-  ],
-  "minimumReleaseAgeBehaviour": "timestamp-optional",
-  "prCreation": "immediate",
-  "rebaseWhen": "never",
-  "addLabels": [
-    "dependencies"
-  ],
-  "enabledManagers": [
-    "github-actions",
-    "maven",
-    "nuget",
-    "gradle",
-    "gradle-wrapper",
-    "npm",
-    "cargo",
-    "dockerfile",
-    "pre-commit",
-    "mise"
-  ],
-  "packageRules": [
-    {
-      "description": "Don't group updates by default",
-      "matchPackageNames": [
-        "*"
-      ],
-      "groupName": null
-    },
-    {
-      "description": "Do not update SonarSource GH actions, we want the branch-version. Only external actions must have commit ID.",
-      "matchManagers": [
-        "github-actions"
-      ],
-      "matchDepNames": [
-        "SonarSource/**"
-      ],
-      "enabled": false
-    },
-    {
-      "description": "Group MSTest dependencies into a single PR",
-      "matchManagers": [
-        "nuget"
-      ],
-      "matchPackageNames": [
-        "MSTest.**",
-        "Microsoft.NET.Test.Sdk",
-        "Verify.MSTest"
-      ],
-      "groupName": "MSTest"
-    },
-    {
-      "description": "Group protobuf packages together - Grpc.Tools bundles protoc which must be compatible with the Google.Protobuf runtime",
-      "matchManagers": [
-        "nuget"
-      ],
-      "matchPackageNames": [
-        "Google.Protobuf",
-        "Grpc.Tools"
-      ],
-      "groupName": "protobuf"
-    },
-    {
-      "description": "Do not update FluentAssertions above v7 due to license change",
-      "matchManagers": [
-        "nuget"
-      ],
-      "matchPackageNames": [
-        "FluentAssertions"
-      ],
-      "allowedVersions": "<8.0.0"
-    },
-    {
-      "description": "Group parent POM updates into a single PR",
-      "matchManagers": [
-        "maven"
-      ],
-      "matchPackageNames": [
-        "org.sonarsource.parent:parent",
-        "com.sonarsource.parent:parent"
-      ],
-      "groupName": "Parent",
-      "groupSlug": "parent"
-    },
-    {
-      "description": "Group Roslyn dependencies into a single PR",
-      "matchManagers": [
-        "nuget"
-      ],
-      "matchPackageNames": [
-        "Microsoft.CodeAnalysis*"
-      ],
-      "groupName": "Roslyn"
-    }
-  ]
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "description": "Shared Renovate preset for Core Languages & Parsers repositories.",
+    "extends": [
+        "local>SonarSource/renovate-config"
+    ],
+    "minimumReleaseAgeBehaviour": "timestamp-optional",
+    "prCreation": "immediate",
+    "rebaseWhen": "never",
+    "addLabels": [
+        "dependencies"
+    ],
+    "enabledManagers": [
+        "github-actions",
+        "maven",
+        "nuget",
+        "gradle",
+        "gradle-wrapper",
+        "npm",
+        "cargo",
+        "dockerfile",
+        "pre-commit",
+        "mise"
+    ],
+    "packageRules": [
+        {
+            "description": "Don't group updates by default",
+            "matchPackageNames": [
+                "*"
+            ],
+            "groupName": null
+        },
+        {
+            "description": "Do not update SonarSource GH actions, we want the branch-version. Only external actions must have commit ID.",
+            "matchManagers": [
+                "github-actions"
+            ],
+            "matchDepNames": [
+                "SonarSource/**"
+            ],
+            "enabled": false
+        },
+        {
+            "description": "Group MSTest dependencies into a single PR",
+            "matchManagers": [
+                "nuget"
+            ],
+            "matchPackageNames": [
+                "MSTest.**",
+                "Microsoft.NET.Test.Sdk",
+                "Verify.MSTest"
+            ],
+            "groupName": "MSTest"
+        },
+        {
+            "description": "Group protobuf packages together - Grpc.Tools bundles protoc which must be compatible with the Google.Protobuf runtime",
+            "matchManagers": [
+                "nuget"
+            ],
+            "matchPackageNames": [
+                "Google.Protobuf",
+                "Grpc.Tools"
+            ],
+            "groupName": "protobuf"
+        },
+        {
+            "description": "Do not update FluentAssertions above v7 due to license change",
+            "matchManagers": [
+                "nuget"
+            ],
+            "matchPackageNames": [
+                "FluentAssertions"
+            ],
+            "allowedVersions": "<8.0.0"
+        },
+        {
+            "description": "Group parent POM updates into a single PR",
+            "matchManagers": [
+                "maven"
+            ],
+            "matchPackageNames": [
+                "org.sonarsource.parent:parent",
+                "com.sonarsource.parent:parent"
+            ],
+            "groupName": "Parent",
+            "groupSlug": "parent"
+        },
+        {
+            "description": "Group Roslyn dependencies into a single PR",
+            "matchManagers": [
+                "nuget"
+            ],
+            "matchPackageNames": [
+                "Microsoft.CodeAnalysis*"
+            ],
+            "groupName": "Roslyn"
+        }
+    ]
 }

--- a/quality-corelang-squad.json
+++ b/quality-corelang-squad.json
@@ -1,0 +1,43 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "description": "Shared Renovate preset for Core Languages & Parsers repositories.",
+    "extends": [
+        "github>SonarSource/renovate-config"
+    ],
+    "minimumReleaseAgeBehaviour": "timestamp-optional",
+    "prCreation": "immediate",
+    "rebaseWhen": "never",
+    "addLabels": [
+        "dependencies"
+    ],
+    "enabledManagers": [
+        "github-actions",
+        "maven",
+        "nuget",
+        "gradle",
+        "gradle-wrapper",
+        "npm",
+        "cargo",
+        "pre-commit",
+        "mise"
+    ],
+    "packageRules": [
+        {
+            "description": "Don't group updates by default",
+            "matchPackageNames": [
+                "*"
+            ],
+            "groupName": null
+        },
+        {
+            "description": "Do not update SonarSource GitHub Actions so repositories can stay on branch versions such as @v3.",
+            "matchManagers": [
+                "github-actions"
+            ],
+            "matchDepNames": [
+                "SonarSource/**"
+            ],
+            "enabled": false
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

This moves the shared Core Languages & Parsers Renovate preset out of `SonarSource/core-languages-tooling-public` and into the shared preset repository as `quality-corelang-squad.json`.

The preset name follows the existing squad preset naming in this repository and keeps the consumer syntax standard:

```json
{
  "extends": ["github>SonarSource/renovate-config:quality-corelang-squad"]
}
```

## Preset behavior

This preserves the latest agreed behavior from the temporary preset:

- extend the shared org preset from this repository (`local>SonarSource/renovate-config`)
- use `minimumReleaseAgeBehaviour: "timestamp-optional"`
- create PRs immediately
- keep `rebaseWhen: "never"`
- add the `dependencies` label
- enable only `github-actions`, `maven`, `nuget`, `gradle`, `gradle-wrapper`, `npm`, `cargo`, `dockerfile`, `pre-commit`, and `mise`
- disable grouping by default
- disable updates for `SonarSource/**` GitHub Actions so repositories can stay on floating major refs such as `@v3`
- group MSTest dependencies, including `Verify.MSTest`
- group `Google.Protobuf` with `Grpc.Tools`
- keep `FluentAssertions` below `8.0.0`
- group Sonar parent POM updates
- group Roslyn dependencies

## Included in This PR

- add `quality-corelang-squad.json`
- add a `CODEOWNERS` entry for `@sonarsource/code-quality-core-languages-parsers-squad`
- document the preset in `README.md`

## Naming and Placement

The preset is added as a top-level JSON file because this repository already exposes shareable presets as top-level `<preset>.json` files. Keeping the same layout avoids inventing a second convention and keeps the preset reference short and consistent.

## Follow-up

Repositories can switch to `github>SonarSource/renovate-config:quality-corelang-squad`.

The old `core-languages-tooling-public/renovate-config.json` can be removed in a separate cleanup PR after consumers have migrated.

## Validation

- JSON syntax validated locally
- README updated to describe the same behavior as `quality-corelang-squad.json`
