### PR TITLE
BUILD-11744 remove postUpgradeTasks

### DIFF
--- a/dev-infra-squad.json
+++ b/dev-infra-squad.json
@@ -24,15 +24,6 @@
     ],
     "dependencyDashboard": true,
     "configMigration": true,
-    "allowedPostUpgradeCommands": [
-        "^pre-commit autoupdate"
-    ],
-    "postUpgradeTasks": {
-        "commands": [
-            "pre-commit autoupdate --freeze || true"
-        ],
-        "executionMode": "branch"
-    },
     "addLabels": [
         "dependencies"
     ],


### PR DESCRIPTION
The post upgrade commands are now mostly blocked by the Cloud Renovate server. Remove the custom "pre-commit autoupdate".
