### PR TITLE
PREQ-6794: Add Yarn Berry exact matchHost for Repox npm auth

### DIFF
--- a/default.json
+++ b/default.json
@@ -223,7 +223,7 @@
             "password": "{{ secrets.REPOX_TOKEN }}"
         },
         {
-            "description": "Yarn Berry auth for npm virtual repository in Repox",
+            "description": "Yarn Berry only: exact matchHost required to inject auth into .yarnrc.yml npmRegistries (generic repox.jfrog.io rule above is insufficient)",
             "hostType": "npm",
             "matchHost": "https://repox.jfrog.io/artifactory/api/npm/npm/",
             "username": "renovate-read",

--- a/default.json
+++ b/default.json
@@ -221,6 +221,13 @@
             "matchHost": "repox.jfrog.io",
             "username": "renovate-read",
             "password": "{{ secrets.REPOX_TOKEN }}"
+        },
+        {
+            "description": "Yarn Berry auth for npm virtual repository in Repox",
+            "hostType": "npm",
+            "matchHost": "https://repox.jfrog.io/artifactory/api/npm/npm/",
+            "username": "renovate-read",
+            "password": "{{ secrets.REPOX_TOKEN }}"
         }
     ],
     "customManagers": [


### PR DESCRIPTION
## Summary

- Adds one exact full-path `matchHost` for Yarn Berry: `https://repox.jfrog.io/artifactory/api/npm/npm/` — required because Renovate only overwrites `npmRegistries` entries when `matchHost` matches the registry URL exactly.

## Context

Yarn Berry resolves `${REPOX_TOKEN:-}` to empty credentials unless Renovate injects auth into `.yarnrc.yml`. A hostname-only hostRule is insufficient for Yarn

Validated locally on `code-quality-io`: `yarn install --mode=update-lockfile` succeeds without `REPOX_*` env vars when the exact `npm/npm/` hostRule is present.

## Test plan

- [ ] Merge this PR and re-run Mend Renovate on `code-quality-io`