### PR TITLE
BUILD-11859: Create AMI update PRs immediately

### DIFF
--- a/dev-infra-squad.json
+++ b/dev-infra-squad.json
@@ -71,11 +71,12 @@
             "minimumReleaseAge": "0 days"
         },
         {
-            "description": "Skip minimumReleaseAge for EC2 AMI updates",
+            "description": "Skip minimumReleaseAge for EC2 AMI updates and create PRs immediately",
             "matchDatasources": [
                 "aws-machine-image"
             ],
-            "minimumReleaseAge": "0 days"
+            "minimumReleaseAge": "0 days",
+            "prCreation": "immediate"
         },
         {
             "description": "Skip minimumReleaseAge for GitHub Actions runner base image updates",


### PR DESCRIPTION
## Summary

Linux AMI update branches (`renovate/noble-24.04-1.x`, `renovate/focal-20.04-1.x`, `renovate/jammy-22.04-1.x`) were created in `ci-ami-images` but Renovate did not open PRs because global `prCreation: "not-pending"` waits for the `renovate/stability-days` check to clear. The `aws-machine-image` rule already sets `minimumReleaseAge: "0 days"`, but that alone does not bypass the pending stability-days gate for PR creation.

This change sets `prCreation: "immediate"` on the `aws-machine-image` package rule in `dev-infra-squad.json` so AMI update PRs are opened as soon as the branch is created, without waiting for stability-days.

## Test plan

- [ ] Merge and wait for next self-hosted Renovate run on `ci-ami-images`
- [ ] Confirm PRs are opened for noble/focal/jammy AMI updates (existing branches or recreated)
- [ ] Verify `renovate/stability-days` may still show pending on the branch, but PR exists