### PR TITLE
BUILD-11859: Skip internal checks filter for EC2 AMI updates

### DIFF
--- a/dev-infra-squad.json
+++ b/dev-infra-squad.json
@@ -76,7 +76,8 @@
                 "aws-machine-image"
             ],
             "minimumReleaseAge": "0 days",
-            "prCreation": "immediate"
+            "prCreation": "immediate",
+            "internalChecksFilter": "none"
         },
         {
             "description": "Skip minimumReleaseAge for GitHub Actions runner base image updates",


### PR DESCRIPTION
## Summary

- Add `internalChecksFilter: "none"` to the `aws-machine-image` package rule in `dev-infra-squad.json`
- Completes the BUILD-11859 AMI PR creation fix: `prCreation: "immediate"` (merged in #146) is not enough on its own

## Problem

Self-hosted Renovate on `ci-aws-infra` detected new `noble-24.04` (and other Ubuntu base) AMI updates but did not open PRs. Logs show:

```
Branch renovate/noble-24.04-1.x creation is disabled because internalChecksFilter was not met
```

Updates were marked `pendingChecks: true` while the org default `internalChecksFilter: "strict"` blocks branch creation until stability-days passes. In Renovate 43.210.0, `prCreation: "immediate"` only affects PR timing after a branch exists — it does not bypass the branch-creation gate when `pendingChecks` is true.

## Fix

Set `internalChecksFilter: "none"` alongside the existing `minimumReleaseAge: "0 days"` and `prCreation: "immediate"` for `aws-machine-image`, so EC2 AMI updates are not held back by the global 5-day `minimumReleaseAge` / strict internal checks.

## Test plan

- [ ] Merge and re-run the `ci-aws-infra` Renovate workflow
- [ ] Confirm Renovate opens `renovate/noble-24.04-1.x` (and other pending Ubuntu AMI branches) on `ci-ami-images`