### PR TITLE
BUILD-11904 add npm registryUrls package rule so Renovate resolves via Repox

### DIFF
--- a/default.json
+++ b/default.json
@@ -160,6 +160,15 @@
             ]
         },
         {
+            "description": "Resolve npm packages via Repox (mirrors the public npm registry), so Renovate does not need each repo to commit its own .npmrc to avoid falling back to registry.npmjs.org",
+            "matchDatasources": [
+                "npm"
+            ],
+            "registryUrls": [
+                "https://repox.jfrog.io/artifactory/api/npm/npm/"
+            ]
+        },
+        {
             "description": "Do not update SonarSource Jira automation actions; use branch-version (@v2).",
             "matchDepNames": [
                 "SonarSource/gh-action-lt-backlog/**"


### PR DESCRIPTION
Jira: https://sonarsource.atlassian.net/browse/BUILD-11904

## Problem

`hostRules` in `default.json` only supplies Repox credentials for npm/Yarn (`hostType: npm`) — authentication. There's no `registryUrls` package rule telling Renovate which registry to actually query for the npm datasource, unlike the existing Maven/NuGet package rules that explicitly set `registryUrls` to Repox.

As a result, any repo that doesn't happen to carry a committed `.npmrc` pointing at Repox has Renovate silently fall back to the public npm registry (`registry.npmjs.org`) when it regenerates lock files. This was discovered on `sonar-dummy-js`, where a `lock-file-maintenance` PR rewrote all 322 `resolved` URLs in `package-lock.json` from `repox.jfrog.io` to `registry.npmjs.org` — a recurrence of a prior manual fix (BUILD-9882).

PREQ-6794 ("Renovate does not work for Yarn repositories") fixed the *authentication* side of this for npm/Yarn, but didn't add a registry override, so the underlying gap remains.

## Fix

Add a `packageRules` entry matching the `npm` datasource with `registryUrls` pointing at the Repox npm virtual repo (`https://repox.jfrog.io/artifactory/api/npm/npm/`), which already mirrors the public npm registry — so no repo-specific configuration is required for Renovate to resolve through Repox by default.

## Test plan

- [ ] Trigger a Renovate run (or lock-file-maintenance) on a repo without a committed `.npmrc` (e.g. `sonar-dummy-js`) and confirm `package-lock.json` resolves against `repox.jfrog.io`
- [ ] Confirm no regression for repos that already commit their own `.npmrc`/`.yarnrc.yml`