### PR TITLE
BUILD-11904 BUILD-11905 add npmrc for Repox lockfile resolution, skip pinDigests for dogfood actions

### DIFF
--- a/default.json
+++ b/default.json
@@ -15,6 +15,8 @@
         "^dotnet restore [^;&|]{0,200}$",
         "^bun install$"
     ],
+    "npmrc": "registry=https://repox.jfrog.io/artifactory/api/npm/npm/\n",
+    "npmrcMerge": true,
     "packageRules": [
         {
             "matchDepTypes": [
@@ -23,6 +25,17 @@
             "pinDigests": true,
             "rangeStrategy": "pin",
             "rollbackPrs": true
+        },
+        {
+            "description": "Do not pin digests for SonarSource actions intentionally tracked at @master (dogfooding convention, e.g. 'uses: SonarSource/x@master # dogfood') - the existing trailing comment breaks Renovate's digest-pin write/verify round-trip and aborts the whole branch",
+            "matchManagers": [
+                "github-actions"
+            ],
+            "matchDepNames": [
+                "SonarSource/**"
+            ],
+            "matchCurrentValue": "/^master$/",
+            "pinDigests": false
         },
         {
             "description": "Group GitHub Actions updates",

--- a/default.json
+++ b/default.json
@@ -27,7 +27,7 @@
             "rollbackPrs": true
         },
         {
-            "description": "Do not pin digests for SonarSource actions intentionally tracked at @master (dogfooding convention, e.g. 'uses: SonarSource/x@master # dogfood') - the existing trailing comment breaks Renovate's digest-pin write/verify round-trip and aborts the whole branch",
+            "description": "Do not pin digests for any SonarSource action tracked at the @master branch ref - this also covers actions annotated with a trailing '# dogfood' comment (e.g. 'uses: SonarSource/x@master # dogfood'), where the existing comment breaks Renovate's digest-pin write/verify round-trip and aborts the whole branch",
             "matchManagers": [
                 "github-actions"
             ],


### PR DESCRIPTION
Jira: https://sonarsource.atlassian.net/browse/BUILD-11904, https://sonarsource.atlassian.net/browse/BUILD-11905

## Problem 1 — npm lockfile resolution still falls back to the public registry (BUILD-11904 follow-up)

PR #148 added a `registryUrls` packageRule for the npm datasource, but that only affects Renovate's own datasource *lookups* — not the actual `npm` CLI invoked for `lockFileMaintenance`/artifact updates. Confirmed on `sonar-dummy-js`: PR #127 still resolved `package-lock.json` against `registry.npmjs.org` after #148 merged. This matches multiple upstream reports (e.g. [renovatebot/renovate#35675](https://github.com/renovatebot/renovate/discussions/35675), [#40413](https://github.com/renovatebot/renovate/discussions/40413)) confirming `registryUrls` alone doesn't propagate to the CLI — the `npmrc` top-level config option is needed.

**Fix:** add the top-level `npmrc` option pointing at the Repox npm virtual repo, with `npmrcMerge: true` so repos that already commit their own `.npmrc` still get it merged rather than overridden.

## Problem 2 — `renovate/github-actions` branch fails with "Error updating branch: update failure" (BUILD-11905)

Root cause: SonarSource actions intentionally tracked at the `@master` branch ref carry a trailing `# dogfood` comment, e.g.:
```yaml
uses: SonarSource/ci-github-actions/build-npm@master # dogfood
```
The org-wide `pinDigests: true` rule tries to rewrite this to `@<sha> # master`, but the existing `# dogfood` comment breaks Renovate's write/verify round-trip, so it aborts the whole branch (confirmed in `sonar-dummy-js`'s Renovate logs: `expectedValue: "master", msg: "Value is not updated"`).

**Fix:** add a packageRule matching SonarSource actions at `@master` (`matchCurrentValue: /^master$/`) to disable `pinDigests` for them, since they're intentionally left unpinned to track the moving branch.

## Local testing

Tested per the [Config development](https://xtranet-sonarsource.atlassian.net/wiki/spaces/Platform/pages/3309600872/Engineering+Experience+Squad+Usage+-+Renovate#7\)-Config-development) runbook: pointed `sonar-dummy-js`'s `.github/renovate.json` `extends` at this branch and ran
```
GITHUB_COM_TOKEN=$(gh auth token) LOG_LEVEL=debug renovate --platform=local --secrets '{"REPOX_TOKEN": "..."}'
```
Confirmed:
- `hostRules` correctly picks up the `npmrc`-derived Repox npm rule
- The npm datasource lookup for `jest` now targets `https://repox.jfrog.io/artifactory/api/npm/npm/jest` (401 expected — test used a dummy token)
- No `Error updating branch` / `Value is not updated` for the github-actions manager

(Full `lockFileMaintenance` npm-CLI round-trip couldn't be exercised locally — outside its schedule window in this dry run — so final confirmation will come from watching the next real Renovate run on `sonar-dummy-js`.)

## Test plan

- [x] Local `renovate --platform=local` run against `sonar-dummy-js` with this branch — no regressions, registry redirect confirmed
- [ ] Merge and watch the next scheduled Renovate run on `sonar-dummy-js`: `renovate/lock-file-maintenance-npm-dependencies` resolves via Repox, `renovate/github-actions` no longer errors