### PR TITLE
BUILD-11904 set Repox as the source for lockfile resolution

### DIFF
--- a/default.json
+++ b/default.json
@@ -15,6 +15,8 @@
         "^dotnet restore [^;&|]{0,200}$",
         "^bun install$"
     ],
+    "npmrc": "registry=https://repox.jfrog.io/artifactory/api/npm/npm/\n",
+    "npmrcMerge": true,
     "packageRules": [
         {
             "matchDepTypes": [


### PR DESCRIPTION
Jira: https://sonarsource.atlassian.net/browse/BUILD-11904

Split out of #149.

## Problem

PR #148 added a `registryUrls` packageRule for the npm datasource, but that only affects Renovate's own datasource *lookups* — not the actual `npm` CLI that Renovate itself shells out to for `lockFileMaintenance`/artifact updates. Confirmed on `sonar-dummy-js`: PR #127 still resolved `package-lock.json` against `registry.npmjs.org` after #148 merged. This matches multiple upstream reports (e.g. [renovatebot/renovate#35675](https://github.com/renovatebot/renovate/discussions/35675), [#40413](https://github.com/renovatebot/renovate/discussions/40413)) confirming `registryUrls` alone doesn't propagate to the CLI — Renovate's own `npmrc` config option is needed to configure the CLI invocation.

Note: this is unrelated to `sonar-dummy-js` separately committing its own repo-level `.npmrc` file — that's a different, repo-specific fix. This PR is entirely scoped to `renovate-config`'s shared preset, so every repo using it benefits without needing to commit anything itself.

## Fix

Makes https://repox.jfrog.io/artifactory/api/npm/npm/ the default npm registry
Aligns Renovate behaviour with [config-npm](http://github.com/SonarSource/ci-github-actions/blob/%E2%80%A6/npm_config.sh) and [Developer Box](http://xtranet-sonarsource.atlassian.net/wiki/%E2%80%A6/Developer+Box) configuration

Add the top-level `npmrc` **config option** (a Renovate setting that controls the `.npmrc` content Renovate writes for its own internal `npm` invocations — not a file committed to any repository) pointing at the Repox npm virtual repo, with `npmrcMerge: true` so repos that already commit their own `.npmrc` still get it merged rather than overridden.

## Local testing

Tested per the [Config development](https://xtranet-sonarsource.atlassian.net/wiki/spaces/Platform/pages/3309600872/Engineering+Experience+Squad+Usage+-+Renovate#7\)-Config-development) runbook, against this exact branch (`fix/jcarsique/BUILD-11904-addNpmrcForRepoxLockfileResolution`): pointed a clean checkout of `sonar-dummy-js` master (no repo-level `.npmrc`) `.github/renovate.json` `extends` at it and ran
```
GITHUB_COM_TOKEN=$(gh auth token) LOG_LEVEL=debug renovate --platform=local --secrets '{"REPOX_TOKEN": "..."}'
```
Confirmed `hostRules` picks up the `npmrc`-derived Repox npm rule, and the npm datasource lookup for `jest` targets `https://repox.jfrog.io/artifactory/api/npm/npm/jest` (401 expected — test used a dummy token).

## Test plan

- [x] Local `renovate --platform=local` run against this branch specifically, on a clean `sonar-dummy-js` master checkout with no repo-level `.npmrc` — registry redirect confirmed
- [ ] Merge and watch the next scheduled Renovate run on `sonar-dummy-js`: `renovate/lock-file-maintenance-npm-dependencies` resolves via Repox