### PR TITLE
BUILD-11905 skip pinDigests for SonarSource actions tracked at @master

### DIFF
--- a/default.json
+++ b/default.json
@@ -25,6 +25,17 @@
             "rollbackPrs": true
         },
         {
+            "description": "Do not pin digests for any SonarSource action tracked at the @master branch ref - this also covers actions annotated with a trailing '# dogfood' comment (e.g. 'uses: SonarSource/x@master # dogfood'), where the existing comment breaks Renovate's digest-pin write/verify round-trip and aborts the whole branch",
+            "matchManagers": [
+                "github-actions"
+            ],
+            "matchDepNames": [
+                "SonarSource/**"
+            ],
+            "matchCurrentValue": "/^master$/",
+            "pinDigests": false
+        },
+        {
             "description": "Group GitHub Actions updates",
             "matchManagers": [
                 "github-actions"


### PR DESCRIPTION
Jira: https://sonarsource.atlassian.net/browse/BUILD-11905

Split out of #149.

## Problem

The `renovate/github-actions` branch fails with `Error updating branch: update failure` on `sonar-dummy-js`. Root cause: several workflow files pin internal SonarSource actions to the `master` branch ref with a trailing `# dogfood` comment, e.g.:
```yaml
uses: SonarSource/ci-github-actions/build-npm@master # dogfood
```
The org-wide `pinDigests: true` rule tries to rewrite this to `@<sha> # master`, but the existing `# dogfood` comment breaks Renovate's write/verify round-trip, so it aborts the whole branch (confirmed in `sonar-dummy-js`'s Renovate logs: `expectedValue: "master", msg: "Value is not updated"`).

## Fix

Add a packageRule matching SonarSource actions at `@master` (`matchCurrentValue: /^master$/`) to disable `pinDigests` for them.

Note this is intentionally broader than just dogfood-commented lines — Renovate's `packageRules` matchers can't see trailing comment text (confirmed: no `# dogfood` string appears anywhere in extracted dependency data), so precise scoping to only commented lines isn't achievable via config. A custom regex manager was considered but rejected: it would run alongside the built-in `github-actions` manager on the same lines, risking duplicate/conflicting extraction (a [documented Renovate failure mode](https://github.com/renovatebot/renovate/discussions/25120)). Any SonarSource action pinned at `@master` shouldn't be SHA-pinned regardless of comment, so the broader match is intentional (see discussion on #149).

## Local testing

Tested per the [Config development](https://xtranet-sonarsource.atlassian.net/wiki/spaces/Platform/pages/3309600872/Engineering+Experience+Squad+Usage+-+Renovate#7\)-Config-development) runbook: pointed `sonar-dummy-js`'s `.github/renovate.json` `extends` at the combined branch and ran `renovate --platform=local`. Confirmed no `Error updating branch` / `Value is not updated` for the github-actions manager.

## Test plan

- [ ] Merge and watch the next scheduled Renovate run on `sonar-dummy-js`: `renovate/github-actions` no longer errors