### PR TITLE
PREQ-7228 Do not raise mise patch PRs in corelang preset

### DIFF
--- a/quality-corelang-squad.json
+++ b/quality-corelang-squad.json
@@ -41,6 +41,16 @@
             "enabled": false
         },
         {
+            "description": "Do not raise patch updates for mise-managed tools; repositories should stay on fuzzy major or minor values instead of vendor-specific patch pins",
+            "matchManagers": [
+                "mise"
+            ],
+            "matchUpdateTypes": [
+                "patch"
+            ],
+            "enabled": false
+        },
+        {
             "description": "Group MSTest dependencies into a single PR",
             "matchManagers": [
                 "nuget"


### PR DESCRIPTION
## Summary

Disable patch updates for `mise` dependencies in `quality-corelang-squad.json`.

## Why

We do not want PRs like `SonarSource/sslr#120` (`17.0` -> `17.0.19+10`) anymore.

For `mise`-managed tools, those patch-level PRs tend to pin vendor-specific versions instead of letting the repositories stay on fuzzy major or minor values. In practice that keeps producing failing PRs, especially for Java where the exact OpenJDK-style patch string is not always installable in the same way across repos.

## Change

- add a `packageRules` entry for `matchManagers: ["mise"]`
- disable `matchUpdateTypes: ["patch"]`

This keeps major and minor `mise` PRs enabled, while stopping patch-only PRs.
