### PR TITLE
PREQ-7263 Use token auth instead of username/password for npm hostRules

### DIFF
--- a/default.json
+++ b/default.json
@@ -241,15 +241,13 @@
         {
             "hostType": "npm",
             "matchHost": "repox.jfrog.io",
-            "username": "renovate-read",
-            "password": "{{ secrets.REPOX_TOKEN }}"
+            "token": "{{ secrets.REPOX_TOKEN }}"
         },
         {
             "description": "Yarn Berry only: exact matchHost required to inject auth into .yarnrc.yml npmRegistries (generic repox.jfrog.io rule above is insufficient)",
             "hostType": "npm",
             "matchHost": "https://repox.jfrog.io/artifactory/api/npm/npm/",
-            "username": "renovate-read",
-            "password": "{{ secrets.REPOX_TOKEN }}"
+            "token": "{{ secrets.REPOX_TOKEN }}"
         }
     ],
     "customManagers": [


### PR DESCRIPTION
Jira: PREQ-7263, PREQ-7298

## Problem

Renovate on `sonarcloud-webapp`/`sonarqube-cli` gets a 401 from Repox on every single npm package lookup
(`GET https://repox.jfrog.io/artifactory/api/npm/npm/* → 401`), ever since BUILD-11904 made npm resolution
go through Repox by default.

## Root cause

Renovate's `applyAuthorization` (`util/http/auth.js`) builds the `Authorization` header differently
depending on whether a `hostRule` uses `token` or `username`+`password`:
- `username`+`password` → `Authorization: Basic base64(username:password)`
- `token` (no `authType`) → `Authorization: Bearer <token>` (correct default)

The npm hostRules here used `username: "renovate-read"` + `password: REPOX_TOKEN` — but `renovate-read`
isn't a real Artifactory identity. The real identity behind `REPOX_TOKEN` is
`vault-SonarSource-<repo>-private-reader` (Vault's Artifactory secrets engine names it
`vault-${role_name}`, confirmed via `vault read -field username ...`), scoped via
`applied-permissions/groups:...`, not a literal username/password pair. Sending it as Basic auth with a
placeholder username never matched a real identity, so every authenticated npm lookup 401'd.

Two Artifactory permission gaps were fixed along the way (`re-service-config` #2337 + follow-up, granting
`private-readers` read on the `npm` virtual repo and its public-tier local repos) — necessary groundwork,
since the token itself needed correct scope, but not sufficient: the 401 persisted after both merged.

## Fix

Switch the npm-specific `hostRules` entries from `username`/`password` to `token` (no `authType`, which
correctly defaults to `Bearer`).

## Verification

Isolated and confirmed against the real Repox endpoint using the real Vault-issued token, bypassing
Renovate to test each HTTP layer independently:

| Client | Auth sent | Result |
|---|---|---|
| curl | `Authorization: Bearer <token>` | 200 |
| Node `fetch` | `Authorization: Bearer <token>` | 200 |
| `got` (Renovate's own HTTP lib), same options Renovate logs | `Authorization: Bearer <token>` | 200 |
| Renovate, previous config (`username`+`password`) | `Authorization: Basic base64(renovate-read:token)` | **401** (reproduced) |
| Renovate, this fix (`token`, no `authType`) | `Authorization: Bearer <token>` | **200** |

Local repro used `renovate --platform=local` per the [Config development runbook](https://xtranet-sonarsource.atlassian.net/wiki/spaces/Platform/pages/3309600872/Engineering+Experience+Squad+Usage+-+Renovate#7\)-Config-development), against a minimal package.json including both an unscoped package (`axios`) and the exact scoped packages that were failing in production (`@dagrejs/dagre`, `@date-fns/upgrade`) — all resolved correctly with this fix, zero 401s.

## Test plan

- [x] Local `renovate --platform=local` run with the real Vault token: axios + scoped packages resolve, no 401s
- [ ] Merge and watch the next scheduled Renovate run on `sonarcloud-webapp` and `sonarqube-cli`: no more repox npm 401s