### PR TITLE
PREQ-7277 Resolve Python packages via Repox for release timestamps

### DIFF
--- a/default.json
+++ b/default.json
@@ -182,6 +182,15 @@
             ]
         },
         {
+            "description": "Resolve Python packages via Repox JSON API (not /simple) so upload_time/releaseTimestamps are available for minimumReleaseAge",
+            "matchDatasources": [
+                "pypi"
+            ],
+            "registryUrls": [
+                "https://repox.jfrog.io/artifactory/api/pypi/sonarsource-pypi/pypi/"
+            ]
+        },
+        {
             "description": "Do not update SonarSource Jira automation actions; use branch-version (@v2).",
             "matchDepNames": [
                 "SonarSource/gh-action-lt-backlog/**"


### PR DESCRIPTION
## Summary
- Route the `pypi` datasource through Repox’s PyPI JSON API so Renovate gets `releaseTimestamp` / `upload_time` data.
- Unblocks Python dependency PRs that were skipped under `minimumReleaseAgeBehaviour: timestamp-required` (same pattern as the existing npm Repox rule).

## Test plan
- [ ] Confirm Renovate opens/updates PRs for Python packages that previously lacked release timestamps
- [ ] Spot-check a Cloud Platform repo that uses Repox-hosted Python packages