### PR TITLE
SC-42414 cloud platform renovate config

### DIFF
--- a/cloud-platform-squad.json
+++ b/cloud-platform-squad.json
@@ -92,6 +92,27 @@
             "addLabels": [
                 "github-actions"
             ]
+        },
+        {
+            "description": "Skip minimumReleaseAge for specific python packages",
+            "matchDatasources": [
+                "pypi"
+            ],
+            "matchPackageNames": [
+                "sc_cdk",
+                "pytest-cov",
+                "boto3",
+                "botocore",
+                "aws-cdk-lib",
+                "syrupy",
+                "pytest",
+                "coverage",
+                "cdk_nag",
+                "constructs",
+                "exceptiongroup",
+                "mypy"
+            ],
+            "minimumReleaseAge": "0 days"
         }
     ],
     "customManagers": [

--- a/cloud-platform-squad.json
+++ b/cloud-platform-squad.json
@@ -99,6 +99,7 @@
                 "pypi"
             ],
             "matchPackageNames": [
+                "sc-cdk",
                 "sc_cdk",
                 "pytest-cov",
                 "boto3",
@@ -107,6 +108,7 @@
                 "syrupy",
                 "pytest",
                 "coverage",
+                "cdk-nag",
                 "cdk_nag",
                 "constructs",
                 "exceptiongroup",


### PR DESCRIPTION
----
## Summary by Gitar

- **Renovate configuration:**
    - Added a rule to set `minimumReleaseAge` to `0 days` for specific `pypi` packages.
    - Included internal and testing dependencies like `sc-cdk`, `pytest`, `boto3`, and `aws-cdk-lib` in the override list.
- **PR automation:**
    - Added a new configuration block in `cloud-platform-squad.json` to improve pull request finding and dependency management.

<sub>This will update automatically on new commits.</sub>