### PR TITLE
PREQ-7421 Group ‎quality-corelang monorepo updates

### DIFF
--- a/quality-corelang-squad.json
+++ b/quality-corelang-squad.json
@@ -104,6 +104,14 @@
                 "Microsoft.CodeAnalysis*"
             ],
             "groupName": "Roslyn"
+        },
+        {
+            "description": "Group npm updates per source repository (monorepo), fallback to per dependency",
+            "matchManagers": [
+                "npm"
+            ],
+            "groupName": "{{#if sourceRepo}}{{sourceRepo}} monorepo{{else}}{{depName}}{{/if}}",
+            "groupSlug": "{{#if sourceRepo}}{{sourceRepo}}{{else}}{{depName}}{{/if}}"
         }
     ]
 }

--- a/quality-corelang-squad.json
+++ b/quality-corelang-squad.json
@@ -31,6 +31,18 @@
             "groupName": null
         },
         {
+            "description": "Group updates per source repository (monorepo), fallback to per dependency.",
+            "matchManagers": [
+                "npm",
+                "maven",
+                "gradle",
+                "nuget",
+                "cargo"
+            ],
+            "groupName": "{{#if sourceRepo}}{{sourceRepo}} monorepo{{else}}{{depName}}{{/if}}",
+            "groupSlug": "{{#if sourceRepo}}{{sourceRepo}}{{else}}{{depName}}{{/if}}"
+        },
+        {
             "description": "Do not update SonarSource GH actions, we want the branch-version. Only external actions must have commit ID.",
             "matchManagers": [
                 "github-actions"
@@ -104,14 +116,6 @@
                 "Microsoft.CodeAnalysis*"
             ],
             "groupName": "Roslyn"
-        },
-        {
-            "description": "Group npm updates per source repository (monorepo), fallback to per dependency",
-            "matchManagers": [
-                "npm"
-            ],
-            "groupName": "{{#if sourceRepo}}{{sourceRepo}} monorepo{{else}}{{depName}}{{/if}}",
-            "groupSlug": "{{#if sourceRepo}}{{sourceRepo}}{{else}}{{depName}}{{/if}}"
         }
     ]
 }


### PR DESCRIPTION
----
## Summary by Gitar

- **Dependency Configuration:**
    - Added a new `npm` package rule in `quality-corelang-squad.json` to group updates by source repository.
    - Configured `groupName` and `groupSlug` to use `sourceRepo` or fallback to `depName` for better organization.
    - Expanded grouping logic to include `maven`, `gradle`, `nuget`, and `cargo` package managers.

<sub>This will update automatically on new commits.</sub>