### PR TITLE
DEX-95 Remove duplicated analyzer updates

### DIFF
--- a/ide-xp-team.json
+++ b/ide-xp-team.json
@@ -62,6 +62,13 @@
             "groupName": "github actions",
             "groupSlug": "github-actions",
             "pinDigests": true
+        },
+        {
+            "description": "Analyzer plugins are updated by a separate Cursor automation",
+            "matchPackageNames": [
+                "org.sonarsource.*:sonar-*-plugin"
+            ],
+            "enabled": false
         }
     ]
 }

--- a/ide-xp-team.json
+++ b/ide-xp-team.json
@@ -3,17 +3,13 @@
     "extends": [
         "github>SonarSource/renovate-config"
     ],
+    "timezone": "Europe/Berlin",
+    "description": "Schedule: 20:00-7:00 every weekday",
     "schedule": [
-        "after 7am every weekday",
-        "before 7pm every weekday"
+        "* 20-23,0-7 * * 1-5"
     ],
     "configMigration": true,
     "rebaseWhen": "conflicted",
-    "allowedPostUpgradeCommands": [
-        "^\\./gradlew .{0,500}--write-locks.{0,500}$",
-        "^dotnet restore .{0,200}$",
-        "^bun install$"
-    ],
     "prConcurrentLimit": 10,
     "addLabels": [
         "renovate-dependencies"
@@ -67,6 +63,13 @@
             "description": "Analyzer plugins are updated by a separate Cursor automation",
             "matchPackageNames": [
                 "org.sonarsource.*:sonar-*-plugin"
+            ],
+            "enabled": false
+        },
+        {
+            "description": "Commercial analyzer plugins used in tests only",
+            "matchPackageNames": [
+                "com.sonarsource.*:sonar-*-plugin"
             ],
             "enabled": false
         }


### PR DESCRIPTION
We have some duplicated updates on Eclipse repo between Renovate and the Cursor automation. This change aims to disable analyzer updates from Renovate so that we can focus on Cursor ones.