### PR TITLE
PREQ-7586: Widen cloud-platform-squad Renovate schedule to full Sunday

### DIFF
--- a/cloud-platform-squad.json
+++ b/cloud-platform-squad.json
@@ -4,7 +4,7 @@
         "github>SonarSource/renovate-config"
     ],
     "schedule": [
-        "* 9-11 * * 0"
+        "* * * * 0"
     ],
     "automerge": false,
     "labels": [


### PR DESCRIPTION
PREQ-7586

Widen the `cloud-platform-squad.json` Renovate schedule from a narrow 2-hour weekly
window (`* 9-11 * * 0`, Sundays 09:00-11:00 CET) to the full day (`* * * * 0`).

## Why

Mend Renovate jobs for `sonarcloud-datadog-observability` and `sonarcloud-core-infra`
were stuck in "Scheduled" / showing many "Awaiting Schedule" updates and never opening
PRs. A Mend job log confirmed the root cause: jobs are triggered by push/webhook events
("requested"), not a cron aligned to the schedule window, and consistently ran outside
the 09:00-11:00 CET window:

```
"msg":"Checking schedule(schedule=* 9-11 * * 0, tz=CET, now=2026-07-25T23:40:59.538Z)"
"msg":"Package not scheduled"
"msg":"Skipping branch creation as not within schedule"
```

The repo was confirmed onboarded and enabled (`repoIsOnboarded=true`,
`enabled: true`) — this isn't an access/onboarding issue, purely a scheduling one.
Neither affected repo has ever had a single Renovate PR (one repo dates back to 2019),
consistent with a persistent window/cadence mismatch rather than a one-off miss.

## Change

Widening to `* * * * 0` keeps updates weekend-only (Sunday), matching the squad's
existing intent to avoid weekday disruption, while removing the narrow window that
requires an event-triggered job to land in an exact 2-hour slot. This is also the
narrowest schedule of any squad preset in this repo — every other squad uses a daily
window or at least 5h/week.

## Note

Two separate, unrelated `github-tags` lookup issues were also found on the Mend
dashboards during this investigation (not addressed by this PR):
- `SonarSource/gh-action_terraform` — total lookup failure, likely missing from the
  Renovate GitHub App's repository access list (being added separately).
- `SonarSource/ci-github-actions` / `SonarSource/vault-action-wrapper` — digest
  resolution failures, likely transient; flagged for follow-up if they recur.