### PR TITLE
BUILD-12112: Assign proper squad owners in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,13 @@
 *.md
 
 # squad configuration files
+cloud-platform-squad.json @sonarsource/platform-cloud-engineering-squad
+data-team.json @sonarsource/data-agentic-data-ml-platform-squad
+frontend-engineering-squad.json @sonarsource/platform-front-end-squad
+ide-xp-team.json @sonarsource/remediation-ide-experience-squad
+languages-team.json @sonarsource/security-cloud-squad @sonarsource/security-stl-taint-squad @sonarsource/code-quality-ci-experience-squad
 organization-reporting-squad.json @sonarsource/orchestration-reporting-squad
+orchestration-storage-squad.json @sonarsource/data-agentic-code-data-storage-squad
 quality-abd-squad.json @sonarsource/quality-abd-squad
 quality-corelang-squad.json @sonarsource/code-quality-core-languages-parsers-squad
 quality-jvm-squad.json @sonarsource/quality-jvm-squad


### PR DESCRIPTION
BUILD-12112

Most squad-specific Renovate preset files had no `CODEOWNERS` entry and fell back to
the default `@sonarsource/platform-eng-xp-squad` wildcard, so the owning squads never
got review requests for changes to their own configuration.

## Change

Adds explicit `CODEOWNERS` entries for 6 preset files:

| File | Owner |
|---|---|
| `cloud-platform-squad.json` | `@sonarsource/platform-cloud-engineering-squad` |
| `data-team.json` | `@sonarsource/data-agentic-data-ml-platform-squad` |
| `frontend-engineering-squad.json` | `@sonarsource/platform-front-end-squad` |
| `ide-xp-team.json` | `@sonarsource/remediation-ide-experience-squad` |
| `languages-team.json` | `@sonarsource/security-cloud-squad @sonarsource/security-stl-taint-squad @sonarsource/code-quality-ci-experience-squad` |
| `orchestration-storage-squad.json` | `@sonarsource/data-agentic-code-data-storage-squad` |

## How owners were determined

Cross-referenced three sources per file: git blame in this repo, the actual repos
`extends`-ing each preset (and those repos' own `CODEOWNERS`), and
`SonarSource/re-service-config`'s team-migration records (authoritative source for
current vs. legacy/renamed GitHub team slugs — several plausible-looking team names
turned out to be deprecated). Full evidence table in BUILD-12112.

`languages-team.json` is genuinely shared across several squads (majority owner
`security-cloud-squad`, but also used by repos owned by `security-stl-taint-squad` and
`code-quality-ci-experience-squad`), so it lists all three rather than picking one.

## Intentionally unchanged

- `cpe-team.json` — no current consumer found via code search, and its underlying
  GitHub team (`sonarcloud-cpe-team`) is marked for deletion in the org's own
  team-migration records. Looks orphaned; flagged in BUILD-12112 for confirmation
  rather than guessed at here.
- `dev-infra-squad.json` — EngXP's own CI/infra tooling config (AMIs, Cirrus,
  golden-ami labels), already correctly covered by the default wildcard.

Existing entries (`organization-reporting-squad.json`, `quality-abd-squad.json`,
`quality-corelang-squad.json`, `quality-jvm-squad.json`) were cross-checked against the
same migration records and are still current — left unchanged.