### PR TITLE
PREQ-7823: Use token auth instead of username/password for pypi hostRule

### DIFF
--- a/default.json
+++ b/default.json
@@ -238,8 +238,7 @@
         {
             "hostType": "pypi",
             "matchHost": "repox.jfrog.io",
-            "username": "renovate-read",
-            "password": "{{ secrets.REPOX_TOKEN }}"
+            "token": "{{ secrets.REPOX_TOKEN }}"
         },
         {
             "hostType": "nuget",


### PR DESCRIPTION
PREQ-7823: fixes one of three Renovate Dependency Dashboard lookup failures reported on
sonarcloud-webapp, and likely fixes silent pypi 401s for any other repo using this config.

## Problem

The pypi `hostRule` in `default.json` still used the same Basic-auth pattern already
diagnosed and fixed for npm in 3319fad (PREQ-7263/PREQ-7298):

```json
{ "hostType": "pypi", "matchHost": "repox.jfrog.io", "username": "renovate-read", "password": "{{ secrets.REPOX_TOKEN }}" }
```

The placeholder username `renovate-read` never matches the real identity behind the
Vault-issued `REPOX_TOKEN`, so Basic-authenticated pypi lookups 401 against Repox. On
sonarcloud-webapp this surfaced as:

```
Failed to look up pypi package aws-cdk-lib: no-result
```

Confirmed via `re-service-config`'s Artifactory permission targets that the `private-readers`
group (which backs the Vault-issued token) already has full READ access to every repo backing
the `sonarsource-pypi` virtual repo — this is not an Artifactory permission gap, purely the
auth-method bug.

## Change

Switch to `token`-only auth (defaults to Bearer), matching the existing npm hostRule right
below it:

```json
{ "hostType": "pypi", "matchHost": "repox.jfrog.io", "token": "{{ secrets.REPOX_TOKEN }}" }
```

## Note

The `nuget` hostRule a few lines below has the identical `username`/`password` pattern and is
likely affected by the same bug, but it's out of scope for this ticket (no reported nuget
failures) — flagging for a separate follow-up rather than bundling here.

## Related

- PREQ-7823 (this fix)
- PREQ-7263 / PREQ-7298 (original npm fix, same bug class)