### PR TITLE
PREQ-7965: Add uv PyPI hostRule for Repox Artifactory path

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The preset also includes an additional non-manager grouping rule that groups all
 
 #### Authentication
 
-Provides authentication credentials to https://repox.jfrog.io. The following package managers were tested for compatibility: `npm`, `maven`, `gradle`, `pipenv`, `poetry`, and `nuget`.
+Provides authentication credentials to https://repox.jfrog.io. The following package managers were tested for compatibility: `npm`, `maven`, `gradle`, `pipenv`, `poetry`, `nuget`, and `uv`.
 
 > Note: authentication only works when Renovate is executed using the GitHub app. If you are running locally, see the instructions at [local-testing](#local-testing).
 

--- a/default.json
+++ b/default.json
@@ -241,6 +241,13 @@
             "token": "{{ secrets.REPOX_TOKEN }}"
         },
         {
+            "description": "uv/pip: Artifactory PyPI API path used by some indexes and by Renovate extra index URLs",
+            "hostType": "pypi",
+            "matchHost": "https://repox.jfrog.io/artifactory/api/pypi/",
+            "username": "renovate-read",
+            "password": "{{ secrets.REPOX_TOKEN }}"
+        },
+        {
             "hostType": "nuget",
             "matchHost": "repox.jfrog.io",
             "username": "renovate-read",


### PR DESCRIPTION
Exact matchHost so pep621 can authenticate uv lock against the Artifactory PyPI API.